### PR TITLE
Draw all components of glyph in the grid view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 [[package]]
 name = "norad"
 version = "0.0.3"
-source = "git+https://github.com/linebender/norad?branch=runebender#129c51d9e3f82c5664932addeaea77cd8c89c97d"
+source = "git+https://github.com/linebender/norad?rev=b82522a7#b82522a7e34f07fb83da70142cfb8f51599afc8a"
 dependencies = [
  "druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=22dfeae)",
  "plist 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,7 +710,7 @@ version = "0.2.0"
 dependencies = [
  "druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=22dfeae)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "norad 0.0.3 (git+https://github.com/linebender/norad?branch=runebender)",
+ "norad 0.0.3 (git+https://github.com/linebender/norad?rev=b82522a7)",
 ]
 
 [[package]]
@@ -1032,7 +1032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum norad 0.0.3 (git+https://github.com/linebender/norad?branch=runebender)" = "<none>"
+"checksum norad 0.0.3 (git+https://github.com/linebender/norad?rev=b82522a7)" = "<none>"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 
 [dependencies]
 druid = { git="https://github.com/xi-editor/druid/", rev="22dfeae" }
-norad = { git="https://github.com/linebender/norad", branch="runebender", features=["druid_data"] }
-#norad = "0.0.2"
+norad = { git="https://github.com/linebender/norad", rev="b82522a7", features=["druid_data"] }
+#norad = { git="https://github.com/linebender/norad", branch="runebender", features=["druid_data"] }
 log = "0.4.8"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,9 +1,13 @@
 //! Application state.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use druid::kurbo::{Affine, BezPath, Point};
 use druid::Data;
+use norad::glyph::{AffineTransform, Contour, ContourPoint, Glyph, PointType};
 use norad::{FontInfo, FormatVersion, MetaInfo, Ufo};
 
 #[derive(Clone, Default)]
@@ -11,10 +15,30 @@ pub struct AppState {
     pub file: FontObject,
 }
 
+/// A shared map from glyph names to resolved `BezPath`s.
+type BezCache = Rc<RefCell<HashMap<String, Rc<BezPath>>>>;
+
 #[derive(Clone)]
 pub struct FontObject {
     pub path: Option<PathBuf>,
     pub object: Rc<Ufo>,
+    resolved: BezCache,
+}
+
+/// The main data type for the grid view.
+#[derive(Clone, Data)]
+pub struct GlyphSet {
+    pub object: Rc<Ufo>,
+    resolved: BezCache,
+}
+
+/// A glyph, plus access to the main UFO in order to resolve components in that
+/// glyph.
+#[derive(Clone, Data)]
+pub struct GlyphPlus {
+    pub glyph: Rc<Glyph>,
+    pub ufo: Rc<Ufo>,
+    resolved: BezCache,
 }
 
 impl AppState {
@@ -22,14 +46,64 @@ impl AppState {
         let obj = FontObject {
             path: path.into(),
             object: Rc::new(object),
+            resolved: Rc::new(Default::default()),
         };
         self.file = obj;
     }
 }
 
+impl GlyphPlus {
+    /// Get the fully resolved (including components) bezier path for this glyph.
+    pub fn get_bezier(&self) -> Option<Rc<BezPath>> {
+        get_bezier(self.glyph.name.as_str(), &self.ufo, &self.resolved)
+    }
+}
+
+pub fn get_bezier(name: &str, ufo: &Rc<Ufo>, resolved: &BezCache) -> Option<Rc<BezPath>> {
+    if let Some(resolved) = resolved.borrow().get(name).map(Rc::clone) {
+        return Some(resolved);
+    }
+
+    let glyph = ufo.get_glyph(name)?;
+    let mut path = path_for_glyph(glyph);
+    for comp in glyph
+        .outline
+        .as_ref()
+        .iter()
+        .flat_map(|o| o.components.iter())
+    {
+        match get_bezier(&comp.base, ufo, resolved) {
+            Some(comp_path) => {
+                let affine = convert_affine(&comp.transform);
+                for comp_elem in (affine * &*comp_path).elements() {
+                    path.push(*comp_elem);
+                }
+            }
+            None => log::warn!("missing component {} in glyph {}", comp.base, name),
+        }
+    }
+
+    let path = Rc::new(path);
+    resolved.borrow_mut().insert(name.to_string(), path.clone());
+    Some(path)
+}
+
+fn convert_affine(affine: &AffineTransform) -> Affine {
+    Affine::new([
+        affine.x_scale as f64,
+        affine.xy_scale as f64,
+        affine.yx_scale as f64,
+        affine.y_scale as f64,
+        affine.x_offset as f64,
+        affine.y_offset as f64,
+    ])
+}
+
 impl Data for FontObject {
     fn same(&self, other: &Self) -> bool {
-        self.path == other.path && other.object.same(&self.object)
+        self.path == other.path
+            && other.object.same(&self.object)
+            && self.resolved.same(&other.resolved)
     }
 }
 
@@ -57,6 +131,7 @@ impl std::default::Default for FontObject {
         FontObject {
             path: None,
             object: Rc::new(ufo),
+            resolved: Rc::new(Default::default()),
         }
     }
 }
@@ -65,39 +140,124 @@ pub mod lenses {
     pub mod app_state {
         use std::rc::Rc;
 
-        use super::super::AppState;
+        use super::super::{AppState, GlyphPlus, GlyphSet as GlyphSet_};
         use crate::lens2::Lens2;
-        use norad::{Glyph as Glyph_, GlyphName, Ufo as Ufo_};
+        use norad::GlyphName;
 
-        pub struct Ufo;
+        pub struct GlyphSet;
 
         pub struct Glyph(pub GlyphName);
 
-        impl Lens2<AppState, Rc<Ufo_>> for Ufo {
-            fn get<V, F: FnOnce(&Rc<Ufo_>) -> V>(&self, data: &AppState, f: F) -> V {
-                f(&data.file.object)
+        impl Lens2<AppState, GlyphSet_> for GlyphSet {
+            fn get<V, F: FnOnce(&GlyphSet_) -> V>(&self, data: &AppState, f: F) -> V {
+                let glyphs = GlyphSet_ {
+                    object: Rc::clone(&data.file.object),
+                    resolved: Rc::clone(&data.file.resolved),
+                };
+                f(&glyphs)
             }
-            fn with_mut<V, F: FnOnce(&mut Rc<Ufo_>) -> V>(&self, data: &mut AppState, f: F) -> V {
-                f(&mut data.file.object)
+            fn with_mut<V, F: FnOnce(&mut GlyphSet_) -> V>(&self, data: &mut AppState, f: F) -> V {
+                let mut glyphs = GlyphSet_ {
+                    object: Rc::clone(&data.file.object),
+                    resolved: Rc::clone(&data.file.resolved),
+                };
+                f(&mut glyphs)
             }
         }
 
-        impl Lens2<Rc<Ufo_>, Rc<Glyph_>> for Glyph {
-            fn get<V, F: FnOnce(&Rc<Glyph_>) -> V>(&self, data: &Rc<Ufo_>, f: F) -> V {
-                let glyph = data.get_glyph(&self.0).expect("missing glyph in lens2");
-                f(glyph)
+        impl Lens2<GlyphSet_, GlyphPlus> for Glyph {
+            fn get<V, F: FnOnce(&GlyphPlus) -> V>(&self, data: &GlyphSet_, f: F) -> V {
+                let glyph = data
+                    .object
+                    .get_glyph(&self.0)
+                    .expect("missing glyph in lens2");
+                let glyph = GlyphPlus {
+                    glyph: Rc::clone(glyph),
+                    ufo: Rc::clone(&data.object),
+                    resolved: Rc::clone(&data.resolved),
+                };
+                f(&glyph)
             }
 
-            fn with_mut<V, F: FnOnce(&mut Rc<Glyph_>) -> V>(&self, data: &mut Rc<Ufo_>, f: F) -> V {
+            fn with_mut<V, F: FnOnce(&mut GlyphPlus) -> V>(&self, data: &mut GlyphSet_, f: F) -> V {
                 //FIXME: this is creating a new copy and then throwing it away
                 //this is just so that the signatures work for now, we aren't actually doing any
                 //mutating
-                let mut glyph = data
+                let glyph = data
+                    .object
                     .get_glyph(&self.0)
-                    .map(Rc::clone)
                     .expect("missing glyph in lens2");
+                let mut glyph = GlyphPlus {
+                    glyph: Rc::clone(glyph),
+                    ufo: Rc::clone(&data.object),
+                    resolved: Rc::clone(&data.resolved),
+                };
                 f(&mut glyph)
             }
         }
     }
+}
+
+/// Convert this glyph's path from the UFO representation into a `kurbo::BezPath`
+/// (which we know how to draw.)
+pub fn path_for_glyph(glyph: &Glyph) -> BezPath {
+    /// An outline can have multiple contours, which correspond to subpaths
+    fn add_contour(path: &mut BezPath, contour: &Contour) {
+        let mut close: Option<&ContourPoint> = None;
+
+        if contour.points.is_empty() {
+            return;
+        }
+
+        let first = &contour.points[0];
+        path.move_to((first.x as f64, first.y as f64));
+        if first.typ != PointType::Move {
+            close = Some(first);
+        }
+
+        let mut idx = 1;
+        let mut controls = Vec::with_capacity(2);
+
+        let mut add_curve = |to_point: Point, controls: &mut Vec<Point>| {
+            match controls.as_slice() {
+                &[] => path.line_to(to_point),
+                &[a] => path.quad_to(a, to_point),
+                &[a, b] => path.curve_to(a, b, to_point),
+                _illegal => panic!("existence of second point implies first"),
+            };
+            controls.clear();
+        };
+
+        while idx < contour.points.len() {
+            let next = &contour.points[idx];
+            let point = Point::new(next.x as f64, next.y as f64);
+            match next.typ {
+                PointType::OffCurve => controls.push(point),
+                PointType::Line => {
+                    debug_assert!(controls.is_empty(), "line type cannot follow offcurve");
+                    add_curve(point, &mut controls);
+                }
+                PointType::Curve => add_curve(point, &mut controls),
+                PointType::QCurve => {
+                    eprintln!("TODO: handle qcurve");
+                    add_curve(point, &mut controls);
+                }
+                PointType::Move => debug_assert!(false, "illegal move point in path?"),
+            }
+            idx += 1;
+        }
+
+        if let Some(to_close) = close.take() {
+            add_curve((to_close.x as f64, to_close.y as f64).into(), &mut controls);
+        }
+    }
+
+    let mut path = BezPath::new();
+    if let Some(outline) = glyph.outline.as_ref() {
+        outline
+            .contours
+            .iter()
+            .for_each(|c| add_contour(&mut path, c));
+    }
+    path
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,11 @@ fn make_ui() -> impl Widget<AppState> {
         0.,
     );
     col.add_child(
-        Scroll::new(Lens2Wrap::new(GlyphGrid::new(), lenses::app_state::Ufo)).vertical(),
+        Scroll::new(Lens2Wrap::new(
+            GlyphGrid::new(),
+            lenses::app_state::GlyphSet,
+        ))
+        .vertical(),
         1.,
     );
     Controller::new(col)


### PR DESCRIPTION

This handles recursion but does not check for loops, except insofar
as the recursion is actually recursive and the app will crash when
it runs out of stack space.

A complicated thing about components is that they can also have
recursive transformations; one component can include another component,
with a particular transformation, and then that whole entity can be included
as a component with a different transformation.

![Screen Shot 2019-10-08 at 1 53 14 PM](https://user-images.githubusercontent.com/3330916/66419957-fd161e80-e9d2-11e9-8e2e-872738924905.png)