### PR TITLE
Draw grid at high zoom levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,23 @@ dependencies = [
 [[package]]
 name = "druid"
 version = "0.3.0"
+source = "git+https://github.com/xi-editor/druid/?rev=af5fdb0#af5fdb02544afa11d93cca5250e9f557465e1560"
+dependencies = [
+ "druid-derive-data 0.1.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)",
+ "druid-derive-lens 0.1.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)",
+ "druid-shell 0.3.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)",
+ "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent-locale 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unic-langid 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "druid"
+version = "0.3.0"
 source = "git+https://github.com/xi-editor/druid/?rev=c6b37aa#c6b37aa0399f3bc5edf8df681858806645e1c52d"
 dependencies = [
  "druid-derive-data 0.1.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)",
@@ -225,7 +242,27 @@ dependencies = [
 [[package]]
 name = "druid-derive-data"
 version = "0.1.0"
+source = "git+https://github.com/xi-editor/druid/?rev=af5fdb0#af5fdb02544afa11d93cca5250e9f557465e1560"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "druid-derive-data"
+version = "0.1.0"
 source = "git+https://github.com/xi-editor/druid/?rev=c6b37aa#c6b37aa0399f3bc5edf8df681858806645e1c52d"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "druid-derive-lens"
+version = "0.1.0"
+source = "git+https://github.com/xi-editor/druid/?rev=af5fdb0#af5fdb02544afa11d93cca5250e9f557465e1560"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -240,6 +277,33 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "druid-shell"
+version = "0.3.0"
+source = "git+https://github.com/xi-editor/druid/?rev=af5fdb0#af5fdb02544afa11d93cca5250e9f557465e1560"
+dependencies = [
+ "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdk-sys 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gtk 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gtk-sys 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kurbo 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piet-common 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -932,7 +996,7 @@ dependencies = [
 name = "runebender"
 version = "0.2.0"
 dependencies = [
- "druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)",
+ "druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "norad 0.0.3 (git+https://github.com/linebender/norad?branch=temp-druid-patch)",
 ]
@@ -1214,9 +1278,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa6ff10857eb253d1ae16987ebfd27372f4129b0c7a3fa41466fbdf7e453e75"
 "checksum direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "315aa929e68ba066cb6fb86f1b22af24f517e02fd9b5734c4d07e42cb9f4aefa"
 "checksum directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8cdcd739e9351c411b8caf5cab32a27c818cfe06260595da121382ecdd22083d"
+"checksum druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)" = "<none>"
 "checksum druid 0.3.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)" = "<none>"
+"checksum druid-derive-data 0.1.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)" = "<none>"
 "checksum druid-derive-data 0.1.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)" = "<none>"
+"checksum druid-derive-lens 0.1.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)" = "<none>"
 "checksum druid-derive-lens 0.1.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)" = "<none>"
+"checksum druid-shell 0.3.0 (git+https://github.com/xi-editor/druid/?rev=af5fdb0)" = "<none>"
 "checksum druid-shell 0.3.0 (git+https://github.com/xi-editor/druid/?rev=c6b37aa)" = "<none>"
 "checksum dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1639bbfd6765e92a40267d217a7acbac5b49320b68013f39a8e4376aa8c1e091"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-druid = { git="https://github.com/xi-editor/druid/", rev="c6b37aa" }
+druid = { git="https://github.com/xi-editor/druid/", rev="af5fdb0" }
 norad = { git="https://github.com/linebender/norad", branch="temp-druid-patch", features=["druid"] }
 log = "0.4.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn make_ui() -> impl Widget<AppState> {
             .unwrap_or_else(|| "Untitled".to_string())
     });
     col.add_child(
-        SizedBox::new(Align::centered(Padding::uniform(5.0, label))).height(40.),
+        SizedBox::new(Align::centered(Padding::new(5.0, label))).height(40.),
         0.,
     );
     col.add_child(

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -20,9 +20,8 @@ impl Editor {
 }
 
 impl Widget<EditorState> for Editor {
-    fn paint(&mut self, ctx: &mut PaintCtx, state: &BaseState, data: &EditorState, _env: &Env) {
+    fn paint(&mut self, ctx: &mut PaintCtx, _: &BaseState, data: &EditorState, _env: &Env) {
         use druid::piet::{Color, RenderContext};
-        //paint_checkerboard(ctx, data.session.viewport.zoom);
         let rect =
             Rect::ZERO.with_size((CANVAS_SIZE.to_vec2() * data.session.viewport.zoom).to_size());
         ctx.fill(rect, &Color::WHITE);
@@ -30,7 +29,7 @@ impl Widget<EditorState> for Editor {
         draw::draw_session(
             ctx,
             data.session.viewport,
-            state.size(),
+            ctx.region().to_rect(),
             &data.metrics,
             &data.session,
             &data.ufo,


### PR DESCRIPTION
One for @madig: This also bumps the version of druid we're using, which fixes
an issue where the main glyph view would be laggy with large files open.

![Screen Shot 2019-10-29 at 1 26 03 PM](https://user-images.githubusercontent.com/3330916/67792560-bb1b4e00-fa4f-11e9-8f42-2c65645775d5.png)
![Screen Shot 2019-10-29 at 1 26 11 PM](https://user-images.githubusercontent.com/3330916/67792563-bbb3e480-fa4f-11e9-9056-e800e3de9bc0.png)
