### PR TITLE
Add 'tools' scaffolding and implement select tool

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,7 @@
+//! shared constants
+
+use druid::kurbo::Size;
+use druid::Selector;
+
+pub const CANVAS_SIZE: Size = Size::new(5000., 5000.);
+pub const REQUEST_FOCUS: Selector = Selector::new("runebender.request-focus");

--- a/src/design_space.rs
+++ b/src/design_space.rs
@@ -95,7 +95,7 @@ impl DVec2 {
         DVec2 { x, y }
     }
 
-    fn from_raw(vec2: impl Into<Vec2>) -> DVec2 {
+    pub fn from_raw(vec2: impl Into<Vec2>) -> DVec2 {
         let vec2 = vec2.into();
         DVec2::new(vec2.x.round(), vec2.y.round())
     }
@@ -139,7 +139,7 @@ impl ViewPort {
         self.affine().inverse()
     }
 
-    fn from_screen(&self, point: impl Into<Point>) -> DPoint {
+    pub fn from_screen(&self, point: impl Into<Point>) -> DPoint {
         let point = self.inverse_affine() * point.into();
         DPoint::new(point.x.round(), point.y.round())
     }
@@ -221,7 +221,7 @@ impl Mul<f64> for DVec2 {
 
 impl From<(f64, f64)> for DPoint {
     fn from(src: (f64, f64)) -> DPoint {
-        DPoint::new(src.0, src.1)
+        DPoint::new(src.0.round(), src.1.round())
     }
 }
 

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -1,16 +1,21 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use druid::kurbo::{Rect, Shape};
+use druid::kurbo::{Point, Rect, Shape};
 use druid::Data;
 use norad::{Glyph, GlyphName, Ufo};
 
 use crate::component::Component;
-use crate::design_space::ViewPort;
+use crate::design_space::{DPoint, DVec2, ViewPort};
 use crate::guides::Guide;
-use crate::path::{EntityId, Path};
+use crate::path::{EntityId, Path, PathPoint};
 
 type UndoStack = ();
+
+/// Minimum distance in screen units that a click must occur to be considered
+/// on a point?
+//TODO: this doesn't feel very robust; items themselves should have hitzones?
+const MIN_CLICK_DISTANCE: f64 = 10.0;
 
 /// The editing state of a particular glyph.
 #[derive(Debug, Clone, Data)]
@@ -69,11 +74,271 @@ impl EditSession {
     pub fn work_bounds(&self) -> Rect {
         self.work_bounds
     }
+
+    pub fn selection_mut(&mut self) -> &mut BTreeSet<EntityId> {
+        Arc::make_mut(&mut self.selection)
+    }
+
+    pub fn paths_mut(&mut self) -> &mut Vec<Path> {
+        Arc::make_mut(&mut self.paths)
+    }
+
+    pub fn guides_mut(&mut self) -> &mut Vec<Guide> {
+        Arc::make_mut(&mut self.guides)
+    }
+
+    pub fn iter_points(&self) -> impl Iterator<Item = &PathPoint> {
+        self.paths.iter().flat_map(|p| p.points().iter())
+    }
+
+    /// For hit testing; iterates 'clickable items' (right now just points
+    /// and guides) near a given point.
+    pub fn iter_items_near_point<'a>(
+        &'a self,
+        point: Point,
+        max_dist: Option<f64>,
+    ) -> impl Iterator<Item = EntityId> + 'a {
+        let max_dist = max_dist.unwrap_or(MIN_CLICK_DISTANCE);
+        self.paths
+            .iter()
+            .flat_map(|p| p.points().iter())
+            .filter(move |p| p.screen_dist(self.viewport, point) <= max_dist)
+            .map(|p| p.id)
+            .chain(
+                self.guides
+                    .iter()
+                    .filter(move |g| g.screen_dist(self.viewport, point) <= max_dist)
+                    .map(|g| g.id),
+            )
+    }
+
+    /// Return the index of the path that is currently drawing. To be currently
+    /// drawing, there must be a single currently selected point.
+    fn active_path_idx(&self) -> Option<usize> {
+        if self.selection.len() == 1 {
+            let active = self.selection.iter().next().unwrap();
+            self.paths.iter().position(|p| *p == *active)
+        } else {
+            None
+        }
+    }
+
+    pub fn active_path_mut(&mut self) -> Option<&mut Path> {
+        match self.active_path_idx() {
+            Some(idx) => self.paths_mut().get_mut(idx),
+            None => None,
+        }
+    }
+
+    pub fn active_path(&self) -> Option<&Path> {
+        match self.active_path_idx() {
+            Some(idx) => self.paths.get(idx),
+            None => None,
+        }
+    }
+
+    pub fn path_point_for_id(&self, id: EntityId) -> Option<PathPoint> {
+        self.paths
+            .iter()
+            .find(|p| **p == id)
+            .and_then(|path| path.path_point_for_id(id))
+    }
+
+    pub fn path_for_point_mut(&mut self, point: EntityId) -> Option<&mut Path> {
+        self.paths_mut().iter_mut().find(|p| **p == point)
+    }
+
+    /// If there is a single on curve point selected, toggle it between corner and smooth
+    pub fn toggle_selected_on_curve_type(&mut self) {
+        if self.selection.len() == 1 {
+            let point = self.selection.iter().copied().next().unwrap();
+            let path = self.active_path_mut().unwrap();
+            path.toggle_on_curve_point_type(point);
+        }
+    }
+
+    /// if a guide his horizontal or vertical, toggle between the two.
+    pub fn toggle_guide(&mut self, id: EntityId, pos: Point) {
+        let pos = self.viewport.from_screen(pos);
+        if let Some(guide) = self.guides_mut().iter_mut().find(|g| g.id == id) {
+            guide.toggle_vertical_horiz(pos);
+        }
+    }
+
+    pub fn delete_selection(&mut self) {
+        let to_delete = PathSelection::new(&self.selection);
+        self.selection_mut().clear();
+        for path_points in to_delete.iter() {
+            if let Some(path) = self.path_for_point_mut(path_points[0]) {
+                path.delete_points(path_points);
+            } else if path_points[0].is_guide() {
+                self.guides_mut().retain(|g| !path_points.contains(&g.id));
+            }
+        }
+        self.paths_mut().retain(|p| !p.points().is_empty());
+    }
+
+    /// Select all points.
+    //NOTE: should this select other things too? Which ones?
+    pub fn select_all(&mut self) {
+        *self.selection_mut() = self.iter_points().map(|p| p.id).collect();
+    }
+
+    /// If the current selection is a single point, select the next point
+    /// on that path.
+    pub fn select_next(&mut self) {
+        if self.selection.len() != 1 {
+            return;
+        }
+        let id = self.selection.iter().next().copied().unwrap();
+        self.selection_mut().clear();
+        let id = self
+            .paths
+            .iter()
+            .find(|p| **p == id)
+            .map(|path| path.next_point(id).id)
+            .unwrap_or(id);
+        self.selection_mut().insert(id);
+    }
+
+    /// If the current selection is a single point, select the previous point
+    /// on that path.
+    pub fn select_prev(&mut self) {
+        if self.selection.len() != 1 {
+            return;
+        }
+        let id = self.selection.iter().next().copied().unwrap();
+        self.selection_mut().clear();
+        let id = self
+            .paths
+            .iter()
+            .find(|p| **p == id)
+            .map(|path| path.prev_point(id).id)
+            .unwrap_or(id);
+        self.selection_mut().insert(id);
+    }
+
+    pub fn select_path(&mut self, point: Point, toggle: bool) -> bool {
+        let path_idx = match self
+            .paths
+            .iter()
+            .position(|p| p.screen_dist(self.viewport, point) < MIN_CLICK_DISTANCE)
+        {
+            Some(idx) => idx,
+            None => return false,
+        };
+
+        let points: Vec<_> = self.paths[path_idx].points().to_owned();
+        for point in points {
+            if !self.selection_mut().insert(point.id) && toggle {
+                self.selection_mut().remove(&point.id);
+            }
+        }
+        true
+    }
+
+    pub(crate) fn nudge_selection(&mut self, nudge: DVec2) {
+        if self.selection.is_empty() {
+            return;
+        }
+
+        let to_nudge = PathSelection::new(&self.selection);
+        for path_points in to_nudge.iter() {
+            if let Some(path) = self.path_for_point_mut(path_points[0]) {
+                path.nudge_points(path_points, nudge);
+            } else if path_points[0].is_guide() {
+                for id in path_points {
+                    if let Some(guide) = self.guides_mut().iter_mut().find(|g| g.id == *id) {
+                        guide.nudge(nudge);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn add_guide(&mut self, point: Point) {
+        // if one or two points are selected, use them. else use argument point.
+        let guide = match self.selection.len() {
+            1 => {
+                let id = *self.selection.iter().next().unwrap();
+                if !id.is_guide() {
+                    let p = self.path_point_for_id(id).map(|pp| pp.point).unwrap();
+                    Some(Guide::horiz(p))
+                } else {
+                    None
+                }
+            }
+            2 => {
+                let mut iter = self.selection.iter().cloned();
+                let id1 = iter.next().unwrap();
+                let id2 = iter.next().unwrap();
+                if !id1.is_guide() && !id2.is_guide() {
+                    let p1 = self.path_point_for_id(id1).map(|pp| pp.point).unwrap();
+                    let p2 = self.path_point_for_id(id2).map(|pp| pp.point).unwrap();
+                    Some(Guide::angle(p1, p2))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        let guide =
+            guide.unwrap_or_else(|| Guide::horiz(DPoint::from_screen(point, self.viewport)));
+        self.selection_mut().clear();
+        self.selection_mut().insert(guide.id);
+        self.guides_mut().push(guide);
+    }
 }
 
 fn rect_same(one: &Rect, two: &Rect) -> bool {
-    one.x0.same(&two.x0)
-        && one.x1.same(&two.x1)
-        && one.y0.same(&two.y0)
-        && one.y1.same(&two.y1)
+    one.x0.same(&two.x0) && one.x1.same(&two.x1) && one.y0.same(&two.y0) && one.y1.same(&two.y1)
+}
+
+/// A helper for iterating through a selection in per-path chunks.
+struct PathSelection {
+    inner: Vec<EntityId>,
+}
+
+impl PathSelection {
+    fn new(src: &BTreeSet<EntityId>) -> PathSelection {
+        let mut inner: Vec<_> = src.iter().copied().collect();
+        inner.sort();
+        PathSelection { inner }
+    }
+
+    fn iter(&self) -> PathSelectionIter {
+        PathSelectionIter {
+            inner: &self.inner,
+            idx: 0,
+        }
+    }
+}
+
+struct PathSelectionIter<'a> {
+    inner: &'a [EntityId],
+    idx: usize,
+}
+
+impl<'a> Iterator for PathSelectionIter<'a> {
+    type Item = &'a [EntityId];
+    fn next(&mut self) -> Option<&'a [EntityId]> {
+        if self.idx >= self.inner.len() {
+            return None;
+        }
+        let path_id = self.inner[self.idx].parent;
+        let end_idx = self.inner[self.idx..]
+            .iter()
+            .position(|p| p.parent != path_id)
+            .map(|idx| idx + self.idx)
+            .unwrap_or(self.inner.len());
+        let range = self.idx..end_idx;
+        self.idx = end_idx;
+        // probably unnecessary, but we don't expect empty slices
+        if range.start == range.end {
+            None
+        } else {
+            Some(&self.inner[range])
+        }
+    }
 }

--- a/src/guides.rs
+++ b/src/guides.rs
@@ -20,7 +20,7 @@ pub enum GuideLine {
 
 impl Guide {
     fn new(guide: GuideLine) -> Self {
-        let id = EntityId::new_with_parent(0);
+        let id = EntityId::new_for_guide();
         Guide { id, guide }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app_delegate;
 mod component;
+mod consts;
 mod data;
 mod design_space;
 mod draw;
@@ -9,7 +10,9 @@ mod edit_session;
 mod guides;
 mod lens2;
 mod menus;
+mod mouse;
 mod path;
+mod tools;
 pub mod widgets;
 
 use druid::widget::{Align, Column, DynLabel, Padding, Scroll, SizedBox};

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,0 +1,370 @@
+//! Easier handling of mouse events.
+//!
+//! Handling the various permutations and combinations of mouse events is messy,
+//! repetitive, and error prone.
+//!
+//! This module implements a state machine that handles the raw event processing,
+//! identifying important events and transitions.
+//!
+//! # Use
+//!
+//! The state machine itself is exposed via the [`Mouse`] struct. You are
+//! responsible for instantiating this struct, and it is expected to persist
+//! between mouse events.
+//!
+//! To react to state changes, you must implement the [`MouseDelegate`] trait;
+//! you only need to implement the methods you are interested in.
+//!
+//! When a mouse event arrives, you pass the event along with your delegate to
+//! the [`Mouse`] struct; if that event causes a state change, the corresponding
+//! method on your delegate will be called.
+//!
+//! # Example
+//! ```
+//! use runebender::mouse::{Mouse, MouseDelegate};
+//! use druid::shell::window::{MouseEvent, MouseButton, KeyModifiers};
+//! use druid::kurbo::Point;
+//!
+//! struct SimpleDelegate(usize);
+//!
+//! impl MouseDelegate<()> for SimpleDelegate {
+//!     fn left_click(&mut self, _event: &MouseEvent, _data: &mut T) -> bool {
+//!         self.0 += 1;
+//!     }
+//! }
+//!
+//! let event = MouseEvent {
+//!     pos: Point::new(20., 20.,),
+//!     mods: KeyModifiers::None,
+//!     count: 1,
+//!     button: MouseButton::Left,
+//! };
+//!
+//! let mut mouse = Mouse::default();
+//! let mut delegate = SimpleDelegate(0);
+//! mouse.mouse_down(event.clone(), &mut (), &mut delegate);
+//! assert_eq!(delegate.0, 0);
+//! mouse.mouse_up(event.clone(), &mut (), &mut delegate);
+//! assert_eq!(delegate.0, 1);
+//! ```
+
+use druid::kurbo::Point;
+use druid::{KeyModifiers, MouseButton, MouseEvent};
+use std::mem;
+
+const DEFAULT_MIN_DRAG_DISTANCE: f64 = 10.0;
+
+/// Handles raw mouse events, parsing them into gestures that it forwards
+/// to a delegate.
+#[derive(Debug, Clone)]
+pub struct Mouse {
+    state: MouseState,
+    /// The distance the mouse must travel with a button down for it to
+    /// be considered a drag gesture.
+    pub min_drag_distance: f64,
+}
+
+/// A convenience type for passing around mouse events while keeping track
+/// of the event type.
+#[derive(Debug, Clone)]
+pub enum TaggedEvent {
+    Down(MouseEvent),
+    Up(MouseEvent),
+    Moved(MouseEvent),
+}
+
+#[derive(Debug, Clone)]
+enum MouseState {
+    /// No mouse buttons are active.
+    Up(MouseEvent),
+    /// A mouse button has been pressed.
+    Down(MouseEvent),
+    /// The mouse has been moved some threshold distance with a button pressed.
+    Drag {
+        start: MouseEvent,
+        current: MouseEvent,
+    },
+    /// A state only used as a placeholder during event handling.
+    #[doc(hidden)]
+    Transition,
+}
+
+/// The state of an in-progress drag gesture.
+#[derive(Debug, Clone, Copy)]
+#[allow(unused)]
+pub struct Drag<'a> {
+    /// The event that started this drag
+    pub start: &'a MouseEvent,
+    /// The previous event in this drag
+    pub prev: &'a MouseEvent,
+    /// The current event in this drag
+    pub current: &'a MouseEvent,
+}
+
+/// A trait for types that want fine grained information about mouse events.
+pub trait MouseDelegate<T> {
+    /// Called on any mouse movement.
+    #[allow(unused)]
+    fn mouse_moved(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the left mouse button is pressed.
+    #[allow(unused)]
+    fn left_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the left mouse button is released.
+    #[allow(unused)]
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the left mouse button is released, if there has not already
+    /// been a drag event.
+    #[allow(unused)]
+    fn left_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the mouse moves a minimum distance with the left mouse
+    /// button pressed.
+    #[allow(unused)]
+    fn left_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the mouse moves after a drag gesture has been recognized.
+    #[allow(unused)]
+    fn left_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the left mouse button is released, after a drag gesture
+    /// has been recognized.
+    #[allow(unused)]
+    fn left_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    /// Called when the right mouse button is pressed.
+    #[allow(unused)]
+    fn right_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the right mouse button is released.
+    #[allow(unused)]
+    fn right_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    /// Called when the right mouse button is released, if there has not already
+    /// been a drag event.
+    #[allow(unused)]
+    fn right_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    /// Called when the mouse moves a minimum distance with the right mouse
+    /// button pressed.
+    #[allow(unused)]
+    fn right_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the mouse moves after a drag gesture has been recognized.
+    #[allow(unused)]
+    fn right_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    /// Called when the right mouse button is released, after a drag gesture
+    /// has been recognized.
+    #[allow(unused)]
+    fn right_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn other_down(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_up(&mut self, _event: &MouseEvent, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_click(&mut self, _event: &MouseEvent, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn other_drag_began(&mut self, _drag: Drag, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_drag_changed(&mut self, _drag: Drag, _data: &mut T) {}
+    #[allow(unused)]
+    fn other_drag_ended(&mut self, _drag: Drag, _data: &mut T) {}
+
+    #[allow(unused)]
+    fn cancel(&mut self, data: &mut T);
+}
+
+impl std::default::Default for Mouse {
+    fn default() -> Mouse {
+        Mouse {
+            min_drag_distance: DEFAULT_MIN_DRAG_DISTANCE,
+            state: MouseState::Up(MouseEvent {
+                pos: Point::ZERO,
+                mods: KeyModifiers::default(),
+                count: 0,
+                button: MouseButton::Left,
+            }),
+        }
+    }
+}
+
+impl Mouse {
+    /// The current position of  the mouse.
+    pub fn pos(&self) -> Point {
+        match &self.state {
+            MouseState::Up(e) => e.pos,
+            MouseState::Down(e) => e.pos,
+            MouseState::Drag { current, .. } => current.pos,
+            _ => panic!("transition is not an actual state :/"),
+        }
+    }
+
+    pub fn mouse_event<T>(
+        &mut self,
+        event: TaggedEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        match event {
+            TaggedEvent::Up(event) => self.mouse_up(event, data, delegate),
+            TaggedEvent::Down(event) => self.mouse_down(event, data, delegate),
+            TaggedEvent::Moved(event) => self.mouse_moved(event, data, delegate),
+        }
+    }
+
+    pub fn mouse_moved<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => {
+                delegate.mouse_moved(&event, data);
+                MouseState::Up(event)
+            }
+            MouseState::Down(prev) => {
+                if prev.pos.distance(event.pos) > self.min_drag_distance {
+                    let drag = Drag::new(&prev, &prev, &event);
+                    if prev.button.is_left() {
+                        delegate.left_drag_began(drag, data)
+                    } else if prev.button.is_right() {
+                        delegate.right_drag_began(drag, data)
+                    } else {
+                        delegate.other_drag_began(drag, data)
+                    };
+                    MouseState::Drag {
+                        start: prev,
+                        current: event,
+                    }
+                } else {
+                    MouseState::Down(prev)
+                }
+            }
+            MouseState::Drag { start, current } => {
+                let drag = Drag::new(&start, &current, &event);
+                if start.button.is_left() {
+                    delegate.left_drag_changed(drag, data)
+                } else if start.button.is_right() {
+                    delegate.right_drag_changed(drag, data)
+                } else {
+                    delegate.other_drag_changed(drag, data)
+                };
+                MouseState::Drag {
+                    start,
+                    current: event,
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    pub fn mouse_down<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => {
+                if event.button.is_left() {
+                    delegate.left_down(&event, data)
+                } else if event.button.is_right() {
+                    delegate.right_down(&event, data)
+                } else {
+                    delegate.other_down(&event, data)
+                };
+                MouseState::Down(event)
+            }
+            MouseState::Down(prev) => {
+                assert!(prev.button != event.button);
+                // if a second button is pressed while we're handling an event
+                // we just ignore it. At some point we could consider an event for this.
+                MouseState::Down(prev)
+            }
+            MouseState::Drag { start, .. } => {
+                if start.button != event.button {
+                    log::warn!("mouse click while drag in progress; not correctly receiving mouse up events?");
+                }
+                MouseState::Drag {
+                    start,
+                    current: event,
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    pub fn mouse_up<T>(
+        &mut self,
+        event: MouseEvent,
+        data: &mut T,
+        delegate: &mut dyn MouseDelegate<T>,
+    ) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        self.state = match prev_state {
+            MouseState::Up(_) => MouseState::Up(event),
+            MouseState::Down(prev) => {
+                if event.button == prev.button {
+                    if prev.button.is_left() {
+                        delegate.left_up(&event, data);
+                        delegate.left_click(&event, data);
+                    } else if prev.button.is_right() {
+                        delegate.right_up(&event, data);
+                        delegate.right_click(&event, data);
+                    } else {
+                        delegate.other_up(&event, data);
+                        delegate.other_click(&event, data);
+                    };
+                    MouseState::Up(event)
+                } else {
+                    MouseState::Down(prev)
+                }
+            }
+            MouseState::Drag { start, current } => {
+                if event.button == start.button {
+                    let drag = Drag {
+                        start: &start,
+                        current: &event,
+                        prev: &current,
+                    };
+                    if start.button.is_left() {
+                        delegate.left_up(&event, data);
+                        delegate.left_drag_ended(drag, data);
+                    } else if start.button.is_right() {
+                        delegate.left_up(&event, data);
+                        delegate.right_drag_ended(drag, data);
+                    } else {
+                        delegate.left_up(&event, data);
+                        delegate.other_drag_ended(drag, data);
+                    };
+                    MouseState::Up(event)
+                } else {
+                    MouseState::Drag { start, current }
+                }
+            }
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+    }
+
+    fn cancel<T>(&mut self, data: &mut T, delegate: &mut dyn MouseDelegate<T>) {
+        let prev_state = mem::replace(&mut self.state, MouseState::Transition);
+        let last_event = match prev_state {
+            MouseState::Down(event) => event,
+            MouseState::Up(event) => event,
+            MouseState::Drag { current, .. } => current,
+            MouseState::Transition => panic!("ahhhhhhh"),
+        };
+        delegate.cancel(data);
+        self.state = MouseState::Up(last_event);
+    }
+}
+
+impl<'a> Drag<'a> {
+    fn new(start: &'a MouseEvent, prev: &'a MouseEvent, current: &'a MouseEvent) -> Drag<'a> {
+        Drag {
+            start,
+            prev,
+            current,
+        }
+    }
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,10 +5,13 @@ use super::design_space::{DPoint, DVec2, ViewPort};
 use druid::kurbo::{BezPath, Point, Vec2};
 use druid::Data;
 
+const RESERVED_ID_COUNT: usize = 5;
+const GUIDE_TYPE_ID: usize = 1;
+
 /// We give paths & points unique integer identifiers.
 fn next_id() -> usize {
     use std::sync::atomic::{AtomicUsize, Ordering};
-    static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(RESERVED_ID_COUNT);
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
@@ -41,11 +44,20 @@ pub struct Path {
 }
 
 impl EntityId {
-    pub(crate) fn new_with_parent(parent: usize) -> Self {
+    pub fn new_with_parent(parent: usize) -> Self {
         EntityId {
             parent,
             point: next_id(),
         }
+    }
+
+    #[inline]
+    pub fn new_for_guide() -> Self {
+        EntityId::new_with_parent(GUIDE_TYPE_ID)
+    }
+
+    pub fn is_guide(self) -> bool {
+        self.parent == GUIDE_TYPE_ID
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,0 +1,45 @@
+//! A tool accepts user input and modifies the canvas.
+
+mod select;
+pub use select::Select;
+
+use crate::edit_session::EditSession;
+use crate::mouse::{Mouse, TaggedEvent};
+use druid::{Env, EventCtx, KeyEvent, PaintCtx};
+
+/// A trait for representing the logic of a tool; that is, something that handles
+/// mouse and keyboard events, and modifies the current [`EditSession`].
+pub trait Tool {
+    /// Called once per `paint()` call in the editor widget, this gives tools
+    /// an opportunity to draw on the canvas.
+    ///
+    /// As an example, the `Select` (arrow) widget uses this to paint the current
+    /// selection rectangle, if a drag gesture is in progress.
+    ///
+    /// # Note:
+    ///
+    /// When drawing, coordinates in 'design space' may need to be converted to
+    /// 'screen space'; conversion methods are available via the [`ViewPort`]
+    /// at `data.viewport`.
+    #[allow(unused)]
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, env: &Env) {}
+    /// Called on each key_down event in the parent.
+    #[allow(unused)]
+    fn key_down(&mut self, key: &KeyEvent, ctx: &mut EventCtx, data: &mut EditSession, env: &Env) {}
+    /// Called on each key_up event in the parent.
+    #[allow(unused)]
+    fn key_up(&mut self, key: &KeyEvent, ctx: &mut EventCtx, data: &mut EditSession, env: &Env) {}
+    /// Called with each mouse event. The `mouse` argument is a reference to a [`Mouse`]
+    /// struct that is shared between all tools; a particular `Tool` can implement the
+    /// [`MouseDelegate`] trait and pass the events to `Mouse` instance.
+    #[allow(unused)]
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+        env: &Env,
+    ) {
+    }
+}

--- a/src/tools/select.rs
+++ b/src/tools/select.rs
@@ -1,0 +1,225 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use druid::kurbo::{Point, Rect, Vec2};
+use druid::piet::{Color, RenderContext};
+use druid::{
+    Data, Env, EventCtx, HotKey, KeyCode, KeyEvent, MouseEvent, PaintCtx, RawMods, SysMods,
+};
+
+use crate::design_space::DVec2;
+use crate::edit_session::EditSession;
+use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
+use crate::path::EntityId;
+use crate::tools::Tool;
+
+const SELECTION_RECT_BG_COLOR: Color = Color::rgba8(0xDD, 0xDD, 0xDD, 0x55);
+const SELECTION_RECT_STROKE_COLOR: Color = Color::rgb8(0x53, 0x8B, 0xBB);
+
+/// The state of the selection tool.
+#[derive(Debug, Default, Clone)]
+pub struct Select {
+    /// when a drag is in progress, this is the state of the selection at the start
+    /// of the drag.
+    prev_selection: Option<Arc<BTreeSet<EntityId>>>,
+    drag_rect: Option<Rect>,
+    last_drag_pos: Option<Point>,
+    last_pos: Point,
+}
+
+impl Tool for Select {
+    fn paint(&mut self, ctx: &mut PaintCtx, _data: &EditSession, _env: &Env) {
+        if let Some(rect) = self.drag_rect {
+            ctx.fill(rect, &SELECTION_RECT_BG_COLOR);
+            ctx.stroke(rect, &SELECTION_RECT_STROKE_COLOR, 1.0);
+        }
+    }
+
+    fn key_down(&mut self, event: &KeyEvent, ctx: &mut EventCtx, data: &mut EditSession, _: &Env) {
+        use KeyCode::*;
+        match event {
+            e if e.key_code == ArrowLeft
+                || e.key_code == ArrowDown
+                || e.key_code == ArrowUp
+                || e.key_code == ArrowRight =>
+            {
+                self.nudge(data, event);
+            }
+            e if e.key_code == Backspace => {
+                data.delete_selection();
+            }
+            //FIXME: these two should be menu items.
+            e if HotKey::new(SysMods::Cmd, "g").matches(e) => data.add_guide(self.last_pos),
+            e if HotKey::new(SysMods::Cmd, "a").matches(e) => data.select_all(),
+            e if HotKey::new(None, KeyCode::Tab).matches(e) => data.select_next(),
+            //TODO: add Shift to SysMods
+            e if HotKey::new(RawMods::Shift, KeyCode::Tab).matches(e) => data.select_next(),
+            _ => return,
+        }
+        ctx.invalidate();
+    }
+
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+        _: &Env,
+    ) {
+        let pre_rect = self.drag_rect;
+        let pre_data = data.clone();
+        mouse.mouse_event(event, data, self);
+        if !rect_equality(pre_rect, self.drag_rect) || !pre_data.same(data) {
+            ctx.invalidate();
+        }
+    }
+}
+
+impl Select {
+    fn update_selection_for_drag(
+        &self,
+        data: &mut EditSession,
+        prev_sel: &BTreeSet<EntityId>,
+        rect: Rect,
+        shift: bool,
+    ) {
+        let in_select_rect = data
+            .iter_points()
+            .filter(|p| rect.contains(p.to_screen(data.viewport)))
+            .map(|p| p.id)
+            .collect();
+        let new_sel = if shift {
+            prev_sel
+                .symmetric_difference(&in_select_rect)
+                .copied()
+                .collect()
+        } else {
+            prev_sel.union(&in_select_rect).copied().collect()
+        };
+        *data.selection_mut() = new_sel;
+    }
+
+    fn nudge(&mut self, data: &mut EditSession, event: &KeyEvent) {
+        let mut nudge = match event.key_code {
+            KeyCode::ArrowLeft => Vec2::new(-1.0, 0.),
+            KeyCode::ArrowRight => Vec2::new(1.0, 0.),
+            KeyCode::ArrowUp => Vec2::new(0.0, 1.0),
+            KeyCode::ArrowDown => Vec2::new(0.0, -1.0),
+            _ => unreachable!(),
+        };
+
+        if event.mods.meta {
+            nudge *= 100.;
+        } else if event.mods.shift {
+            nudge *= 10.;
+        }
+        data.nudge_selection(DVec2::from_raw(nudge));
+    }
+}
+
+impl MouseDelegate<EditSession> for Select {
+    fn mouse_moved(&mut self, event: &MouseEvent, _data: &mut EditSession) {
+        self.last_pos = event.pos;
+    }
+
+    fn left_down(&mut self, event: &MouseEvent, data: &mut EditSession) {
+        if event.count == 1 {
+            let sel = data.iter_items_near_point(event.pos, None).next();
+            if let Some(point_id) = sel {
+                if !event.mods.shift {
+                    // when clicking a point, if it is not selected we set it as the selection,
+                    // otherwise we keep the selection intact for a drag.
+                    if !data.selection.contains(&point_id) {
+                        data.selection_mut().clear();
+                        data.selection_mut().insert(point_id);
+                    }
+                } else if !data.selection_mut().remove(&point_id) {
+                    data.selection_mut().insert(point_id);
+                }
+            } else if !event.mods.shift {
+                data.selection_mut().clear();
+            }
+        } else if event.count == 2 {
+            let sel = data.iter_items_near_point(event.pos, None).next().clone();
+            match sel {
+                Some(id)
+                    if data
+                        .path_point_for_id(id)
+                        .map(|p| p.is_on_curve())
+                        .unwrap_or(false) =>
+                {
+                    data.toggle_selected_on_curve_type()
+                }
+                Some(id) if id.is_guide() => data.toggle_guide(id, event.pos),
+                _ => {
+                    data.select_path(event.pos, event.mods.shift);
+                }
+            }
+        }
+    }
+
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut EditSession) {
+        self.prev_selection = None;
+        self.drag_rect = None;
+    }
+
+    fn left_drag_began(&mut self, drag: Drag, data: &mut EditSession) {
+        self.prev_selection = if data
+            .iter_items_near_point(drag.start.pos, None)
+            .next()
+            .is_some()
+        {
+            None
+        } else {
+            Some(data.selection.clone())
+        };
+    }
+
+    fn left_drag_changed(&mut self, drag: Drag, data: &mut EditSession) {
+        if let Some(prev_selection) = self.prev_selection.as_ref() {
+            let rect = Rect::from_points(drag.current.pos, drag.start.pos);
+            self.drag_rect = Some(rect);
+            self.update_selection_for_drag(data, prev_selection, rect, drag.current.mods.shift);
+        } else {
+            let last_drag_pos = self.last_drag_pos.unwrap_or(drag.start.pos);
+            let dvec = drag.current.pos - last_drag_pos;
+            let drag_vec = dvec * data.viewport.zoom.recip();
+            let drag_vec = DVec2::from_raw((drag_vec.x.floor(), drag_vec.y.floor()));
+            if drag_vec.hypot() > 0. {
+                // multiple small drag updates that don't make up a single point in design
+                // space should be aggregated
+                let aligned_drag_delta = drag_vec.to_screen(data.viewport);
+                let aligned_last_drag = last_drag_pos + aligned_drag_delta;
+                self.last_drag_pos = Some(aligned_last_drag);
+                //HACK: because this is used to compute last_drag_pos,
+                //we only swap the y-axis at the end  ¯\_(ツ)_/¯
+                let mut drag_vec = drag_vec;
+                drag_vec.y = -drag_vec.y;
+                data.nudge_selection(drag_vec);
+            }
+        }
+    }
+
+    fn left_drag_ended(&mut self, _drag: Drag, _data: &mut EditSession) {
+        self.last_drag_pos = None;
+    }
+
+    fn cancel(&mut self, data: &mut EditSession) {
+        if let Some(prev) = self.prev_selection.take() {
+            data.selection = prev;
+        }
+        self.drag_rect = None;
+    }
+}
+
+fn rect_equality(one: Option<Rect>, two: Option<Rect>) -> bool {
+    match (one, two) {
+        (None, None) => true,
+        (Some(one), Some(two)) => {
+            one.x0 == two.x0 && one.x1 == two.x1 && one.y0 == two.y0 && one.y1 == two.y1
+        }
+        _ => false,
+    }
+}
+

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -5,22 +5,40 @@ use druid::{
     BaseState, BoxConstraints, Data, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
+use crate::consts::{CANVAS_SIZE, REQUEST_FOCUS};
 use crate::data::EditorState;
 use crate::draw;
+use crate::mouse::{Mouse, TaggedEvent};
+use crate::tools::{Select, Tool};
 
 /// The root widget of the glyph editor window.
-pub struct Editor {}
-
-pub const CANVAS_SIZE: Size = Size::new(5000., 5000.);
+pub struct Editor {
+    mouse: Mouse,
+    tool: Box<dyn Tool>,
+}
 
 impl Editor {
     pub fn new() -> Editor {
-        Editor {}
+        Editor {
+            mouse: Mouse::default(),
+            tool: Box::new(Select::default()),
+        }
+    }
+
+    fn send_mouse(
+        &mut self,
+        event: TaggedEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditorState,
+        env: &Env,
+    ) {
+        self.tool
+            .mouse_event(event, &mut self.mouse, ctx, &mut data.session, env);
     }
 }
 
 impl Widget<EditorState> for Editor {
-    fn paint(&mut self, ctx: &mut PaintCtx, _: &BaseState, data: &EditorState, _env: &Env) {
+    fn paint(&mut self, ctx: &mut PaintCtx, _: &BaseState, data: &EditorState, env: &Env) {
         use druid::piet::{Color, RenderContext};
         let rect =
             Rect::ZERO.with_size((CANVAS_SIZE.to_vec2() * data.session.viewport.zoom).to_size());
@@ -34,6 +52,8 @@ impl Widget<EditorState> for Editor {
             &data.session,
             &data.ufo,
         );
+
+        self.tool.paint(ctx, &data.session, env);
     }
 
     fn layout(
@@ -46,7 +66,16 @@ impl Widget<EditorState> for Editor {
         (CANVAS_SIZE.to_vec2() * data.session.viewport.zoom).to_size()
     }
 
-    fn event(&mut self, _event: &Event, _ctx: &mut EventCtx, _data: &mut EditorState, _env: &Env) {}
+    fn event(&mut self, event: &Event, ctx: &mut EventCtx, data: &mut EditorState, env: &Env) {
+        match event {
+            Event::Command(c) if c.selector == REQUEST_FOCUS => ctx.request_focus(),
+            Event::KeyDown(k) => self.tool.key_down(k, ctx, &mut data.session, env),
+            Event::MouseUp(m) => self.send_mouse(TaggedEvent::Up(m.clone()), ctx, data, env),
+            Event::MouseMoved(m) => self.send_mouse(TaggedEvent::Moved(m.clone()), ctx, data, env),
+            Event::MouseDown(m) => self.send_mouse(TaggedEvent::Down(m.clone()), ctx, data, env),
+            _ => (),
+        };
+    }
 
     fn update(
         &mut self,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -7,6 +7,5 @@ mod scroll_zoom;
 
 pub use controller::Controller;
 pub use editor::Editor;
-use editor::CANVAS_SIZE;
 pub use grid::GlyphGrid;
 pub use scroll_zoom::ScrollZoom;

--- a/src/widgets/scroll_zoom.rs
+++ b/src/widgets/scroll_zoom.rs
@@ -4,9 +4,8 @@ use druid::{
     BaseState, BoxConstraints, Env, Event, EventCtx, LayoutCtx, PaintCtx, UpdateCtx, Widget,
 };
 
+use crate::consts::{CANVAS_SIZE, REQUEST_FOCUS};
 use crate::data::EditorState;
-
-use super::CANVAS_SIZE;
 
 const MIN_ZOOM: f64 = 0.02;
 const MAX_ZOOM: f64 = 50.;
@@ -120,7 +119,9 @@ impl<T: Widget<EditorState>> Widget<EditorState> for ScrollZoom<T> {
         match event {
             Event::Size(size) if !self.is_setup => {
                 self.set_initial_viewport(data, *size);
-                ctx.request_focus();
+                //HACK: because of how WidgetPod works this event isn't propogated,
+                //so we need to use a command to tell the Editor struct to request focus
+                ctx.submit_command(REQUEST_FOCUS.into(), None);
             }
             Event::MouseMoved(mouse) => {
                 self.mouse = mouse.pos;
@@ -131,17 +132,6 @@ impl<T: Widget<EditorState>> Widget<EditorState> for ScrollZoom<T> {
                 ctx.set_handled();
                 ctx.invalidate();
                 return;
-            }
-            // for debugging zoom:
-            Event::KeyUp(key) if key.unmod_text() == Some("j") => {
-                self.zoom(data, Vec2::new(50., 0.), ctx.size());
-                self.child.reset_scrollbar_fade(ctx);
-                ctx.invalidate();
-            }
-            Event::KeyUp(key) if key.unmod_text() == Some("k") => {
-                self.zoom(data, Vec2::new(-50., 0.), ctx.size());
-                self.child.reset_scrollbar_fade(ctx);
-                ctx.invalidate();
             }
             _ => (),
         }


### PR DESCRIPTION
The majority of this code was written a few months ago; this was
cleaning it up and adapting it to Runebender.

With this patch, it should be possible to start implementing tools,
although it is not currently possible to switch tools.

It is also now possible to, in rudimentary ways, modify the open glyph:


![Screen Shot 2019-11-01 at 5 07 34 PM](https://user-images.githubusercontent.com/3330916/68057600-c929d280-fccc-11e9-9292-7f3ce62fd983.png)
![Screen Shot 2019-11-01 at 5 08 47 PM](https://user-images.githubusercontent.com/3330916/68057605-c9c26900-fccc-11e9-864c-ef4d887f356b.png)
