### PR TITLE
Add basic context menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,17 +175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-graphics"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "direct2d"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,11 +207,11 @@ dependencies = [
 
 [[package]]
 name = "druid"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "druid-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "druid-shell 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "druid-shell 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,12 +233,11 @@ dependencies = [
 
 [[package]]
 name = "druid-shell"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -628,7 +616,7 @@ name = "norad"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "druid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "druid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-xml 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -922,7 +910,7 @@ dependencies = [
 name = "runebender"
 version = "0.2.0"
 dependencies = [
- "druid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "druid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "norad 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1201,13 +1189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
-"checksum core-graphics 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f15b3cb55687886a6b66953123621e5a1529a91a01666d646fb64baa13f900f0"
 "checksum direct2d 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa6ff10857eb253d1ae16987ebfd27372f4129b0c7a3fa41466fbdf7e453e75"
 "checksum direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "315aa929e68ba066cb6fb86f1b22af24f517e02fd9b5734c4d07e42cb9f4aefa"
 "checksum directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8cdcd739e9351c411b8caf5cab32a27c818cfe06260595da121382ecdd22083d"
-"checksum druid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06edcf99625d3f0b27fefd134416995e3bc8009a0505e3a49aa4613b83198010"
+"checksum druid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfc2c5a80baa05c7e949e6f32c02846cca5f0e390b9deb43d24d9171ec730a0"
 "checksum druid-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa8d9846ac11feb8640aaf2fde998d57cd00d6c65f4d04a0bb025895f2076a5a"
-"checksum druid-shell 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c91aa267308af436b89557706bc225b3cb54fd641369145e83c776069b249083"
+"checksum druid-shell 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b72f74db43368e53c26abc5587ccfdcb5d259b647f5fd322873eeef4f7c6f18"
 "checksum dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1639bbfd6765e92a40267d217a7acbac5b49320b68013f39a8e4376aa8c1e091"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-druid = "0.3.0"
+druid = "0.3.2"
 norad = { version= "0.0.4", features = ["druid"]}
 log = "0.4.8"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,7 +6,11 @@ pub const CANVAS_SIZE: Size = Size::new(5000., 5000.);
 
 /// Commands and Selectors
 pub mod cmd {
+    use druid::kurbo::Point;
     use druid::Selector;
+
+    use crate::path::EntityId;
+
     /// Hack. Sent at launch to the editor widget, so it knows to request keyboard focus.
     pub const REQUEST_FOCUS: Selector = Selector::new("runebender.request-focus");
 
@@ -36,4 +40,20 @@ pub mod cmd {
 
     /// Sent when the 'reset zoom' menu item is selected
     pub const ZOOM_DEFAULT: Selector = Selector::new("runebender.zoom-default");
+
+    /// Sent when the 'add guide' context menu item is selected
+    ///
+    /// The arguments **must** be a `Point`, where the guide will be added.
+    pub const ADD_GUIDE: Selector = Selector::new("runebender.add-guide");
+
+    /// Sent when the 'toggle guide' context menu item is selected
+    ///
+    /// The arguments **must** be a `ToggleGuideCmdArgs`.
+    pub const TOGGLE_GUIDE: Selector = Selector::new("runebender.toggle-guide");
+
+    /// Arguments passed along with the TOGGLE_GUIDE command
+    pub struct ToggleGuideCmdArgs {
+        pub id: EntityId,
+        pub pos: Point,
+    }
 }

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -1,12 +1,36 @@
 //! Application menus.
 
-use crate::consts;
+use druid::kurbo::Point;
+
 use druid::command::{sys as sys_cmd, Command};
 use druid::menu::{self, sys as sys_menu, MenuDesc, MenuItem};
 use druid::shell::dialog::{FileDialogOptions, FileSpec};
 use druid::{Data, LocalizedString, SysMods};
 
+use crate::consts;
+use crate::data::{AppState, EditorState};
+
 const UFO_FILE_TYPE: FileSpec = FileSpec::new("Font Object", &["ufo"]);
+
+/// Context menu's inner menu must have type T == the root app state.
+pub fn make_context_menu(data: &EditorState, pos: Point) -> MenuDesc<AppState> {
+    let mut menu = MenuDesc::empty().append(MenuItem::new(
+        LocalizedString::new("menu-item-add-guide").with_placeholder("Add Guide".into()),
+        Command::new(consts::cmd::ADD_GUIDE, pos),
+    ));
+
+    // only show 'toggle guide' if a guide is selected
+    if data.session.selection.len() == 1 && data.session.selection.iter().all(|s| s.is_guide()) {
+        let id = *data.session.selection.iter().next().unwrap();
+        let args = consts::cmd::ToggleGuideCmdArgs { id, pos };
+        menu = menu.append(MenuItem::new(
+            LocalizedString::new("menu-item-toggle-guide")
+                .with_placeholder("Toggle Guide Orientation".into()),
+            Command::new(consts::cmd::TOGGLE_GUIDE, args),
+        ));
+    }
+    menu
+}
 
 /// The main window/app menu.
 pub(crate) fn make_menu<T: Data>() -> MenuDesc<T> {

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -177,10 +177,21 @@ impl std::default::Default for Mouse {
             min_drag_distance: DEFAULT_MIN_DRAG_DISTANCE,
             state: MouseState::Up(MouseEvent {
                 pos: Point::ZERO,
+                window_pos: Point::ZERO,
                 mods: KeyModifiers::default(),
                 count: 0,
                 button: MouseButton::Left,
             }),
+        }
+    }
+}
+
+impl TaggedEvent {
+    pub fn inner(&self) -> &MouseEvent {
+        match self {
+            TaggedEvent::Down(m) => m,
+            TaggedEvent::Up(m) => m,
+            TaggedEvent::Moved(m) => m,
         }
     }
 }


### PR DESCRIPTION
based on #29, which should go in first.

This lets you add guides and toggle guide orientations by
right-clicking.

This also lets you crash the app, on mac, in some situations I have
not tried very hard to debug, but that's almost certainly a druid issue.