### PR TITLE
Implement basic undo

### DIFF
--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -26,16 +26,16 @@ pub fn make_delegate() -> AppDelegate<AppState> {
                 Some(OpenGlyph::Window(_window_id)) => (), // we want to show this window,
                 None => {
                     let title = payload.to_string();
-                    let payload2 = payload.clone();
+                    let session = EditSession::new(&payload, &data.file.object);
+                    let session2 = session.clone();
 
-                    let new_win = WindowDesc::new(move || make_editor(payload2.clone()))
+                    let new_win = WindowDesc::new(move || make_editor(&session2))
                         .title(LocalizedString::new("").with_placeholder(title))
                         .menu(crate::menus::make_menu::<AppState>());
                     let command = Command::new(druid::command::sys::NEW_WINDOW, new_win);
                     ctx.submit_command(command, None);
                     Arc::make_mut(&mut data.open_glyphs)
                         .insert(payload.clone(), OpenGlyph::Pending);
-                    let session = EditSession::new(&payload, &data.file.object);
                     Arc::make_mut(&mut data.sessions).insert(payload.clone(), session);
                 }
             }
@@ -45,9 +45,9 @@ pub fn make_delegate() -> AppDelegate<AppState> {
     })
 }
 
-fn make_editor(glyph: GlyphName) -> impl Widget<AppState> {
+fn make_editor(session: &EditSession) -> impl Widget<AppState> {
     Lens2Wrap::new(
-        ScrollZoom::new(Editor::new()),
-        lenses::app_state::EditorState(glyph),
+        ScrollZoom::new(Editor::new(session.clone())),
+        lenses::app_state::EditorState(session.name.clone()),
     )
 }

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -10,8 +10,6 @@ use crate::design_space::{DPoint, DVec2, ViewPort};
 use crate::guides::Guide;
 use crate::path::{EntityId, Path, PathPoint};
 
-type UndoStack = ();
-
 /// Minimum distance in screen units that a click must occur to be considered
 /// on a point?
 //TODO: this doesn't feel very robust; items themselves should have hitzones?
@@ -26,7 +24,6 @@ pub struct EditSession {
     pub selection: Arc<BTreeSet<EntityId>>,
     pub components: Arc<Vec<Component>>,
     pub guides: Arc<Vec<Guide>>,
-    pub undo_stack: UndoStack,
     pub viewport: ViewPort,
     #[druid(same_fn = "rect_same")]
     work_bounds: Rect,
@@ -63,7 +60,6 @@ impl EditSession {
             selection: Arc::default(),
             components: Arc::new(components),
             guides: Arc::new(guides),
-            undo_stack: (),
             viewport: ViewPort::default(),
             work_bounds: work_bounds,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod menus;
 mod mouse;
 mod path;
 mod tools;
+mod undo;
 pub mod widgets;
 
 use druid::widget::{Align, Column, DynLabel, Padding, Scroll, SizedBox};

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -71,8 +71,8 @@ fn file_menu<T: Data>() -> MenuDesc<T> {
 
 fn edit_menu<T: Data>() -> MenuDesc<T> {
     MenuDesc::new(LocalizedString::new("common-menu-edit-menu"))
-        .append(sys_menu::common::undo().disabled())
-        .append(sys_menu::common::redo().disabled())
+        .append(sys_menu::common::undo())
+        .append(sys_menu::common::redo())
         .append_separator()
         .append(sys_menu::common::cut().disabled())
         .append(sys_menu::common::copy().disabled())

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -317,14 +317,14 @@ impl Mouse {
             MouseState::Down(prev) => {
                 if event.button == prev.button {
                     if prev.button.is_left() {
-                        delegate.left_up(&event, data);
                         delegate.left_click(&event, data);
+                        delegate.left_up(&event, data);
                     } else if prev.button.is_right() {
-                        delegate.right_up(&event, data);
                         delegate.right_click(&event, data);
+                        delegate.right_up(&event, data);
                     } else {
-                        delegate.other_up(&event, data);
                         delegate.other_click(&event, data);
+                        delegate.other_up(&event, data);
                     };
                     MouseState::Up(event)
                 } else {
@@ -339,14 +339,14 @@ impl Mouse {
                         prev: &current,
                     };
                     if start.button.is_left() {
-                        delegate.left_up(&event, data);
                         delegate.left_drag_ended(drag, data);
+                        delegate.left_up(&event, data);
                     } else if start.button.is_right() {
-                        delegate.left_up(&event, data);
                         delegate.right_drag_ended(drag, data);
+                        delegate.right_up(&event, data);
                     } else {
-                        delegate.left_up(&event, data);
                         delegate.other_drag_ended(drag, data);
+                        delegate.other_up(&event, data);
                     };
                     MouseState::Up(event)
                 } else {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,29 @@ use crate::edit_session::EditSession;
 use crate::mouse::{Mouse, TaggedEvent};
 use druid::{Env, EventCtx, KeyEvent, PaintCtx};
 
+/// Types of state modifications, for the purposes of undo.
+///
+/// Certain state modifications group together in undo; for instance when dragging
+/// a point, each individual edit (each time we receive a `MouseMouved`` event)
+/// is combined into a single edit representing the entire drag.
+///
+/// When a `Tool` handles an event, it returns an `Option<EditType>`, that describes
+/// what (if any) sort of modification it made to the state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditType {
+    /// Any change that always gets its own undo group
+    Normal,
+    NudgeLeft,
+    NudgeRight,
+    NudgeUp,
+    NudgeDown,
+    /// An edit where a drag of some kind is in progress.
+    Drag,
+    /// An edit that finishes a drag; it combines with the previous undo
+    /// group, but not with any subsequent event.
+    DragUp,
+}
+
 /// A trait for representing the logic of a tool; that is, something that handles
 /// mouse and keyboard events, and modifies the current [`EditSession`].
 pub trait Tool {
@@ -21,17 +44,39 @@ pub trait Tool {
     /// When drawing, coordinates in 'design space' may need to be converted to
     /// 'screen space'; conversion methods are available via the [`ViewPort`]
     /// at `data.viewport`.
+    ///
+    /// [`EditSession`]: struct.EditSession.html
+    /// [`ViewPort`]: struct.ViewPort.html
     #[allow(unused)]
     fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, env: &Env) {}
     /// Called on each key_down event in the parent.
     #[allow(unused)]
-    fn key_down(&mut self, key: &KeyEvent, ctx: &mut EventCtx, data: &mut EditSession, env: &Env) {}
+    fn key_down(
+        &mut self,
+        key: &KeyEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+        env: &Env,
+    ) -> Option<EditType> {
+        None
+    }
     /// Called on each key_up event in the parent.
     #[allow(unused)]
-    fn key_up(&mut self, key: &KeyEvent, ctx: &mut EventCtx, data: &mut EditSession, env: &Env) {}
+    fn key_up(
+        &mut self,
+        key: &KeyEvent,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+        env: &Env,
+    ) -> Option<EditType> {
+        None
+    }
     /// Called with each mouse event. The `mouse` argument is a reference to a [`Mouse`]
     /// struct that is shared between all tools; a particular `Tool` can implement the
     /// [`MouseDelegate`] trait and pass the events to `Mouse` instance.
+    ///
+    /// [`Mouse`]: struct.Mouse.html
+    /// [`MouseDelegate`]: ../mouse/trait.MouseDelegate.html
     #[allow(unused)]
     fn mouse_event(
         &mut self,
@@ -40,6 +85,20 @@ pub trait Tool {
         ctx: &mut EventCtx,
         data: &mut EditSession,
         env: &Env,
-    ) {
+    ) -> Option<EditType> {
+        None
+    }
+}
+
+impl EditType {
+    pub fn needs_new_undo_group(self, other: EditType) -> bool {
+        match (self, other) {
+            (EditType::NudgeDown, EditType::NudgeDown) => false,
+            (EditType::NudgeUp, EditType::NudgeUp) => false,
+            (EditType::NudgeLeft, EditType::NudgeLeft) => false,
+            (EditType::NudgeRight, EditType::NudgeRight) => false,
+            (EditType::Drag, EditType::Drag) => false,
+            _ => true,
+        }
     }
 }

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -1,0 +1,68 @@
+//! Managing undo state
+
+use std::collections::VecDeque;
+
+// for no good reason
+const DEFAULT_UNDO_STACK_SIZE: usize = 128;
+
+/// A stack of states that can be undone and redone.
+#[derive(Debug)]
+pub(crate) struct UndoState<T> {
+    max_undo_count: usize,
+    stack: VecDeque<T>,
+    /// The index in `stack` of the current document.
+    live_index: usize,
+}
+
+impl<T> UndoState<T> {
+    pub(crate) fn new(init_state: T) -> Self {
+        Self::new_sized(DEFAULT_UNDO_STACK_SIZE, init_state)
+    }
+
+    fn new_sized(max_undo_count: usize, init_state: T) -> Self {
+        let mut stack = VecDeque::new();
+        stack.push_back(init_state);
+        UndoState {
+            max_undo_count,
+            stack,
+            live_index: 0,
+        }
+    }
+
+    pub(crate) fn undo(&mut self) -> Option<&T> {
+        if self.live_index == 0 {
+            return None;
+        }
+        self.live_index -= 1;
+        self.stack.get(self.live_index)
+    }
+
+    pub(crate) fn redo(&mut self) -> Option<&T> {
+        if self.live_index == self.stack.len() - 1 {
+            return None;
+        }
+        self.live_index += 1;
+        self.stack.get(self.live_index)
+    }
+
+    pub(crate) fn add_undo_group(&mut self, item: T) {
+        if self.live_index < self.stack.len() - 1 {
+            self.stack.split_off(self.live_index + 1);
+        }
+
+        self.live_index += 1;
+        self.stack.push_back(item);
+
+        if self.stack.len() > self.max_undo_count {
+            self.stack.pop_front();
+            self.live_index -= 1;
+        }
+    }
+
+    /// Modify the state for the currently active undo group.
+    /// This might be done if an edit occurs that combines with the previous undo,
+    /// or if we want to save selection state.
+    pub(crate) fn update_current_undo(&mut self, mut f: impl FnMut(&mut T)) {
+        f(self.stack.get_mut(self.live_index).unwrap())
+    }
+}


### PR DESCRIPTION
This is very non-fancy, but proves out the feature, and is wired
to the undo/redo menu items.

I'm heartened by how approximately easy this was. I'm sure there are some bugs in here (and certainly some UX tweaks) but it required no grand adjustments to architecture, which was something I was concerned about.