### PR TITLE
Add tool hotkeys and display current tool name

### DIFF
--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -27,6 +27,8 @@ pub struct EditSession {
     pub viewport: ViewPort,
     #[druid(same_fn = "rect_same")]
     work_bounds: Rect,
+    /// A string describing the current tool
+    pub tool_desc: Arc<str>,
 }
 
 impl EditSession {
@@ -61,6 +63,7 @@ impl EditSession {
             components: Arc::new(components),
             guides: Arc::new(guides),
             viewport: ViewPort::default(),
+            tool_desc: Arc::from("Select"),
             work_bounds: work_bounds,
         }
     }

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1,5 +1,7 @@
 //! the main editor widget.
 
+use std::sync::Arc;
+
 use druid::kurbo::{Point, Rect, Size};
 use druid::menu::ContextMenu;
 use druid::{
@@ -96,8 +98,14 @@ impl Editor {
             consts::cmd::SELECT_ALL => data.session.select_all(),
             consts::cmd::DESELECT_ALL => data.session.clear_selection(),
             consts::cmd::DELETE => data.session.delete_selection(),
-            consts::cmd::SELECT_TOOL => self.tool = Box::new(Select::default()),
-            consts::cmd::PEN_TOOL => self.tool = Box::new(Pen::default()),
+            consts::cmd::SELECT_TOOL => {
+                self.tool = Box::new(Select::default());
+                data.session.tool_desc = Arc::from("Select");
+            }
+            consts::cmd::PEN_TOOL => {
+                self.tool = Box::new(Pen::default());
+                data.session.tool_desc = Arc::from("Pen");
+            }
             consts::cmd::COPY_AS_CODE => self.copy_as_code(ctx, &data.session),
             consts::cmd::ADD_GUIDE => {
                 let point = cmd.get_object::<Point>().unwrap();


### PR DESCRIPTION
This is a temporary alternative to having an actual toolbar; we just
draw the name of the current tool on the screen.

In addition this implements 'V' for select and 'P' for pen.

![Screen Shot 2019-11-11 at 6 12 09 PM](https://user-images.githubusercontent.com/3330916/68628551-efaaf300-04ae-11ea-9446-d26242c48bee.png)
![Screen Shot 2019-11-11 at 6 12 28 PM](https://user-images.githubusercontent.com/3330916/68628552-f0dc2000-04ae-11ea-8c10-c157b72e8f24.png)
