### PR TITLE
Add 'Copy as Code' menu item

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -51,6 +51,9 @@ pub mod cmd {
     /// The arguments **must** be a `ToggleGuideCmdArgs`.
     pub const TOGGLE_GUIDE: Selector = Selector::new("runebender.toggle-guide");
 
+    /// Sent when the 'Copy As Code' menu item is selected.
+    pub const COPY_AS_CODE: Selector = Selector::new("runebender.copy-as-code");
+
     /// Arguments passed along with the TOGGLE_GUIDE command
     pub struct ToggleGuideCmdArgs {
         pub id: EntityId,

--- a/src/copy_as_code.rs
+++ b/src/copy_as_code.rs
@@ -1,0 +1,55 @@
+//! Converting paths to piet drawing code.
+
+use std::fmt::Write;
+
+use crate::edit_session::EditSession;
+use druid::kurbo::{Affine, BezPath, PathEl, Shape};
+
+/// Generates druid-compatible drawing code for all of the `Paths` in this
+/// session, if any exist.
+pub fn make_code_string(session: &EditSession) -> Option<String> {
+    if session.paths.is_empty() {
+        return None;
+    }
+
+    let mut out = String::from("let mut bez = BezPath::new();\n");
+    for path in session.paths.iter() {
+        let mut bezier = path.bezier();
+
+        // glyphs are y-up, but piet generally expects y-down, so we flipy that
+        bezier.apply_affine(Affine::FLIP_Y);
+
+        // and then we set our origin to be equal the origin of our bounding box
+        let bbox = bezier.bounding_box();
+        bezier.apply_affine(Affine::translate(-bbox.origin().to_vec2()));
+
+        if let Err(e) = append_path(&bezier, &mut out) {
+            log::error!("error generating code string: '{}'", e);
+            return None;
+        }
+    }
+
+    Some(out)
+}
+
+fn append_path(path: &BezPath, out: &mut String) -> std::fmt::Result {
+    out.push('\n');
+    for element in path.elements() {
+        match element {
+            PathEl::MoveTo(p) => writeln!(out, "bez.move_to(({:.1}, {:.1}));", p.x, p.y)?,
+            PathEl::LineTo(p) => writeln!(out, "bez.line_to(({:.1}, {:.1}));", p.x, p.y)?,
+            PathEl::QuadTo(p1, p2) => writeln!(
+                out,
+                "bez.quad_to(({:.1}, {:.1}), ({:.1}, {:.1}));",
+                p1.x, p1.y, p2.x, p2.y
+            )?,
+            PathEl::CurveTo(p1, p2, p3) => writeln!(
+                out,
+                "bez.curve_to(({:.1}, {:.1}), ({:.1}, {:.1}), ({:.1}, {:.1}));",
+                p1.x, p1.y, p2.x, p2.y, p3.x, p3.y
+            )?,
+            PathEl::ClosePath => writeln!(out, "bez.close_path();")?,
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod app_delegate;
 mod component;
 mod consts;
+mod copy_as_code;
 mod data;
 mod design_space;
 mod draw;

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -125,15 +125,22 @@ fn view_menu<T: Data>() -> MenuDesc<T> {
 }
 
 fn glyph_menu<T: Data>() -> MenuDesc<T> {
-    MenuDesc::new(LocalizedString::new("menu-glyph-menu").with_placeholder("Glyph".into())).append(
-        MenuItem::new(
-            LocalizedString::new("menu-item-add-component")
-                .with_placeholder("Add Component".into()),
-            consts::cmd::ADD_COMPONENT,
+    MenuDesc::new(LocalizedString::new("menu-glyph-menu").with_placeholder("Glyph".into()))
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-add-component")
+                    .with_placeholder("Add Component".into()),
+                consts::cmd::ADD_COMPONENT,
+            )
+            .hotkey(SysMods::CmdShift, "c")
+            .disabled(),
         )
-        .hotkey(SysMods::CmdShift, "c")
-        .disabled(),
-    )
+        .append_separator()
+        .append(MenuItem::new(
+            LocalizedString::new("menu-item-copy-as-code")
+                .with_placeholder("Copy Paths as Code".into()),
+            consts::cmd::COPY_AS_CODE,
+        ))
 }
 
 fn tools_menu<T: Data>() -> MenuDesc<T> {

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -69,12 +69,17 @@ impl Editor {
     }
 
     fn do_undo(&mut self) -> Option<&EditSession> {
-        //eprintln!("updated undo");
         self.undo.undo()
     }
 
     fn do_redo(&mut self) -> Option<&EditSession> {
         self.undo.redo()
+    }
+
+    fn copy_as_code(&self, env: &mut EventCtx, data: &EditSession) {
+        if let Some(code) = crate::copy_as_code::make_code_string(data) {
+            env.set_clipboard_contents(code);
+        }
     }
 
     /// handle a `Command`. Returns a bool indicating whether the command was
@@ -93,6 +98,7 @@ impl Editor {
             consts::cmd::DELETE => data.session.delete_selection(),
             consts::cmd::SELECT_TOOL => self.tool = Box::new(Select::default()),
             consts::cmd::PEN_TOOL => self.tool = Box::new(Pen::default()),
+            consts::cmd::COPY_AS_CODE => self.copy_as_code(ctx, &data.session),
             consts::cmd::ADD_GUIDE => {
                 let point = cmd.get_object::<Point>().unwrap();
                 data.session.add_guide(*point);


### PR DESCRIPTION
This adds a new item to the 'Glyph' menu; when selected it
will generate Rust code to represent the paths in the glyph,
and copy them to the clipboard.

![Screen Shot 2019-11-11 at 7 05 31 PM](https://user-images.githubusercontent.com/3330916/68630749-4c5ddc00-04b6-11ea-9987-c3ecd201d223.png)

generates:

```rust
let mut bez = BezPath::new();

bez.move_to((208.0, 418.0));
bez.curve_to((323.0, 418.0), (417.0, 324.0), (417.0, 209.0));
bez.curve_to((417.0, 94.0), (323.0, 0.0), (208.0, 0.0));
bez.curve_to((93.0, 0.0), (0.0, 94.0), (0.0, 209.0));
bez.curve_to((0.0, 324.0), (93.0, 418.0), (208.0, 418.0));
bez.close_path();

bez.move_to((108.0, 88.0));
bez.curve_to((67.0, 88.0), (31.0, 70.0), (0.0, 33.0));
bez.line_to((26.0, 0.0));
bez.curve_to((44.0, 29.0), (74.0, 51.0), (108.0, 51.0));
bez.curve_to((139.0, 51.0), (167.0, 34.0), (194.0, 0.0));
bez.line_to((214.0, 31.0));
bez.curve_to((188.0, 65.0), (149.0, 88.0), (108.0, 88.0));
bez.close_path();

bez.move_to((31.0, 62.0));
bez.curve_to((15.0, 62.0), (0.0, 47.0), (0.0, 31.0));
bez.curve_to((0.0, 15.0), (15.0, 0.0), (31.0, 0.0));
bez.curve_to((47.0, 0.0), (62.0, 15.0), (62.0, 31.0));
bez.curve_to((62.0, 47.0), (47.0, 62.0), (31.0, 62.0));
bez.close_path();

bez.move_to((31.0, 62.0));
bez.curve_to((15.0, 62.0), (0.0, 47.0), (0.0, 31.0));
bez.curve_to((0.0, 15.0), (15.0, 0.0), (31.0, 0.0));
bez.curve_to((47.0, 0.0), (62.0, 15.0), (62.0, 31.0));
bez.curve_to((62.0, 47.0), (47.0, 62.0), (31.0, 62.0));
bez.close_path();

```