### PR TITLE
Implement basic paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,10 +325,10 @@ dependencies = [
 [[package]]
 name = "druid"
 version = "0.4.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=3d8de58#3d8de58eca63949aafb9bab37b7a8b4b306494a2"
+source = "git+https://github.com/xi-editor/druid.git?rev=516e832#516e832962668588edbbe165dd443c95ba1227e2"
 dependencies = [
- "druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)",
- "druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)",
+ "druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=516e832)",
+ "druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=516e832)",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.1.2"
-source = "git+https://github.com/xi-editor/druid.git?rev=3d8de58#3d8de58eca63949aafb9bab37b7a8b4b306494a2"
+source = "git+https://github.com/xi-editor/druid.git?rev=516e832#516e832962668588edbbe165dd443c95ba1227e2"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.4.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=3d8de58#3d8de58eca63949aafb9bab37b7a8b4b306494a2"
+source = "git+https://github.com/xi-editor/druid.git?rev=516e832#516e832962668588edbbe165dd443c95ba1227e2"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1229,7 @@ dependencies = [
 name = "runebender"
 version = "0.2.0"
 dependencies = [
- "druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)",
+ "druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=516e832)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lopdf 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "norad 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1559,11 +1559,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "315aa929e68ba066cb6fb86f1b22af24f517e02fd9b5734c4d07e42cb9f4aefa"
 "checksum directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8cdcd739e9351c411b8caf5cab32a27c818cfe06260595da121382ecdd22083d"
 "checksum druid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfc2c5a80baa05c7e949e6f32c02846cca5f0e390b9deb43d24d9171ec730a0"
-"checksum druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)" = "<none>"
+"checksum druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=516e832)" = "<none>"
 "checksum druid-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa8d9846ac11feb8640aaf2fde998d57cd00d6c65f4d04a0bb025895f2076a5a"
-"checksum druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)" = "<none>"
+"checksum druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=516e832)" = "<none>"
 "checksum druid-shell 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b72f74db43368e53c26abc5587ccfdcb5d259b647f5fd322873eeef4f7c6f18"
-"checksum druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=3d8de58)" = "<none>"
+"checksum druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=516e832)" = "<none>"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1639bbfd6765e92a40267d217a7acbac5b49320b68013f39a8e4376aa8c1e091"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-druid = { git = "https://github.com/xi-editor/druid.git", rev = "3d8de58", version = "0.4" }
+druid = { git = "https://github.com/xi-editor/druid.git", rev = "516e832", version = "0.4" }
 norad = { version = "0.0.4", features = ["druid"]}
 log = "0.4.8"
 plist = "0.5"

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -153,8 +153,15 @@ impl EditSession {
         let point = path.points()[0].id;
 
         self.paths_mut().push(path);
-        self.selection_mut().clear();
+        self.clear_selection();
         self.selection_mut().insert(point);
+    }
+
+    pub fn paste_paths(&mut self, paths: Vec<Path>) {
+        self.clear_selection();
+        self.selection_mut()
+            .extend(paths.iter().flat_map(|p| p.points().iter().map(|pt| pt.id)));
+        self.paths_mut().extend(paths);
     }
 
     pub fn add_point(&mut self, point: Point) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod lens2;
 mod menus;
 mod mouse;
 mod path;
+mod plist;
 mod tools;
 mod undo;
 pub mod widgets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod tools;
 mod undo;
 pub mod widgets;
 
-use druid::widget::{Align, Column, DynLabel, Padding, Scroll, SizedBox};
+use druid::widget::{Align, DynLabel, Flex, Padding, Scroll, SizedBox};
 use druid::{AppLauncher, LocalizedString, Widget, WindowDesc};
 
 use data::{lenses, AppState};
@@ -46,7 +46,7 @@ fn main() {
 }
 
 fn make_ui() -> impl Widget<AppState> {
-    let mut col = Column::new();
+    let mut col = Flex::column();
     let label = DynLabel::new(|data: &AppState, _| {
         data.file
             .object

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -77,7 +77,7 @@ fn edit_menu<T: Data>() -> MenuDesc<T> {
         .append_separator()
         .append(platform_menus::common::cut().disabled())
         .append(platform_menus::common::copy())
-        .append(platform_menus::common::paste().disabled())
+        .append(platform_menus::common::paste())
         .append(MenuItem::new(
             LocalizedString::new("menu-item-delete").with_placeholder("Delete".into()),
             consts::cmd::DELETE,

--- a/src/path.rs
+++ b/src/path.rs
@@ -9,7 +9,7 @@ const RESERVED_ID_COUNT: usize = 5;
 const GUIDE_TYPE_ID: usize = 1;
 
 /// We give paths & points unique integer identifiers.
-fn next_id() -> usize {
+pub fn next_id() -> usize {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static NEXT_ID: AtomicUsize = AtomicUsize::new(RESERVED_ID_COUNT);
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
@@ -136,6 +136,20 @@ impl Path {
         }
     }
 
+    pub fn from_raw_parts(
+        id: usize,
+        points: Vec<PathPoint>,
+        trailing: Option<DPoint>,
+        closed: bool,
+    ) -> Self {
+        Path {
+            id,
+            points: Arc::new(points),
+            trailing,
+            closed,
+        }
+    }
+
     pub fn from_norad(src: &norad::glyph::Contour) -> Path {
         use norad::glyph::PointType as NoradPType;
         assert!(
@@ -179,12 +193,7 @@ impl Path {
             points.rotate_left(1);
         }
 
-        Path {
-            id: path_id,
-            points: Arc::new(points),
-            trailing: None,
-            closed,
-        }
+        Path::from_raw_parts(path_id, points, None, closed)
     }
 
     pub fn is_closed(&self) -> bool {

--- a/src/plist.rs
+++ b/src/plist.rs
@@ -1,0 +1,351 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// An enum representing a property list.
+#[derive(Clone, Debug)]
+pub enum Plist {
+    Dictionary(HashMap<String, Plist>),
+    Array(Vec<Plist>),
+    String(String),
+    Integer(i64),
+    Float(f64),
+}
+
+#[derive(Debug)]
+pub enum Error {
+    UnexpectedChar(char),
+    UnclosedString,
+    UnknownEscape,
+    NotAString,
+    ExpectedEquals,
+    ExpectedComma,
+    ExpectedSemicolon,
+    SomethingWentWrong,
+}
+
+enum Token<'a> {
+    Eof,
+    OpenBrace,
+    OpenParen,
+    String(Cow<'a, str>),
+    Atom(&'a str),
+}
+
+fn is_numeric(b: u8) -> bool {
+    (b >= b'0' && b <= b'9') || b == b'.' || b == b'-'
+}
+
+fn is_alnum(b: u8) -> bool {
+    is_numeric(b) || (b >= b'A' && b <= b'Z') || (b >= b'a' && b <= b'z') || b == b'_'
+}
+
+fn is_ascii_digit(b: u8) -> bool {
+    b >= b'0' && b <= b'9'
+}
+
+fn is_hex_upper(b: u8) -> bool {
+    (b >= b'0' && b <= b'9') || (b >= b'A' && b <= b'F')
+}
+
+fn is_ascii_whitespace(b: u8) -> bool {
+    b == b' ' || b == b'\t' || b == b'\r' || b == b'\n'
+}
+
+fn numeric_ok(s: &str) -> bool {
+    let s = s.as_bytes();
+    if s.is_empty() {
+        return false;
+    }
+    if s.iter().all(|&b| is_hex_upper(b)) && !s.iter().all(|&b| is_ascii_digit(b)) {
+        return false;
+    }
+    if s.len() > 1 && s[0] == b'0' {
+        return !s.iter().all(|&b| is_ascii_digit(b));
+    }
+    true
+}
+
+fn skip_ws(s: &str, mut ix: usize) -> usize {
+    while ix < s.len() && is_ascii_whitespace(s.as_bytes()[ix]) {
+        ix += 1;
+    }
+    ix
+}
+
+impl Plist {
+    pub fn parse(s: &str) -> Result<Plist, Error> {
+        let (plist, _ix) = Plist::parse_rec(s, 0)?;
+        // TODO: check that we're actually at eof
+        Ok(plist)
+    }
+
+    #[allow(unused)]
+    pub fn as_dict(&self) -> Option<&HashMap<String, Plist>> {
+        match self {
+            Plist::Dictionary(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn get(&self, key: &str) -> Option<&Plist> {
+        match self {
+            Plist::Dictionary(d) => d.get(key),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn as_array(&self) -> Option<&[Plist]> {
+        match self {
+            Plist::Array(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Plist::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Plist::Integer(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Plist::Integer(i) => Some(*i as f64),
+            Plist::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn into_string(self) -> String {
+        match self {
+            Plist::String(s) => s,
+            _ => panic!("expected string"),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn into_vec(self) -> Vec<Plist> {
+        match self {
+            Plist::Array(a) => a,
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn into_hashmap(self) -> HashMap<String, Plist> {
+        match self {
+            Plist::Dictionary(d) => d,
+            _ => panic!("expected dictionary"),
+        }
+    }
+
+    fn parse_rec(s: &str, ix: usize) -> Result<(Plist, usize), Error> {
+        let (tok, mut ix) = Token::lex(s, ix)?;
+        match tok {
+            Token::Atom(s) => Ok((Plist::parse_atom(s), ix)),
+            Token::String(s) => Ok((Plist::String(s.into()), ix)),
+            Token::OpenBrace => {
+                let mut dict = HashMap::new();
+                loop {
+                    if let Some(ix) = Token::expect(s, ix, b'}') {
+                        return Ok((Plist::Dictionary(dict), ix));
+                    }
+                    let (key, next) = Token::lex(s, ix)?;
+                    let key_str = Token::try_into_string(key)?;
+                    let next = Token::expect(s, next, b'=');
+                    if next.is_none() {
+                        return Err(Error::ExpectedEquals);
+                    }
+                    let (val, next) = Self::parse_rec(s, next.unwrap())?;
+                    dict.insert(key_str, val);
+                    if let Some(next) = Token::expect(s, next, b';') {
+                        ix = next;
+                    } else {
+                        return Err(Error::ExpectedSemicolon);
+                    }
+                }
+            }
+            Token::OpenParen => {
+                let mut list = Vec::new();
+                if let Some(ix) = Token::expect(s, ix, b')') {
+                    return Ok((Plist::Array(list), ix));
+                }
+                loop {
+                    let (val, next) = Self::parse_rec(s, ix)?;
+                    list.push(val);
+                    if let Some(ix) = Token::expect(s, next, b')') {
+                        return Ok((Plist::Array(list), ix));
+                    }
+                    if let Some(next) = Token::expect(s, next, b',') {
+                        ix = next;
+                    } else {
+                        return Err(Error::ExpectedComma);
+                    }
+                }
+            }
+            _ => Err(Error::SomethingWentWrong),
+        }
+    }
+
+    fn parse_atom(s: &str) -> Plist {
+        if numeric_ok(s) {
+            if let Ok(num) = s.parse() {
+                return Plist::Integer(num);
+            }
+            if let Ok(num) = s.parse() {
+                return Plist::Float(num);
+            }
+        }
+        Plist::String(s.into())
+    }
+}
+
+impl<'a> Token<'a> {
+    fn lex(s: &'a str, ix: usize) -> Result<(Token<'a>, usize), Error> {
+        let start = skip_ws(s, ix);
+        if start == s.len() {
+            return Ok((Token::Eof, start));
+        }
+        let b = s.as_bytes()[start];
+        match b {
+            b'{' => Ok((Token::OpenBrace, start + 1)),
+            b'(' => Ok((Token::OpenParen, start + 1)),
+            b'"' => {
+                let mut ix = start + 1;
+                let mut cow_start = ix;
+                let mut buf = String::new();
+                while ix < s.len() {
+                    let b = s.as_bytes()[ix];
+                    match b {
+                        b'"' => {
+                            // End of string
+                            let string = if buf.is_empty() {
+                                s[cow_start..ix].into()
+                            } else {
+                                buf.push_str(&s[cow_start..ix]);
+                                buf.into()
+                            };
+                            return Ok((Token::String(string), ix + 1));
+                        }
+                        b'\\' => {
+                            buf.push_str(&s[cow_start..ix]);
+                            ix += 1;
+                            if ix == s.len() {
+                                return Err(Error::UnclosedString);
+                            }
+                            let b = s.as_bytes()[ix];
+                            match b {
+                                b'"' | b'\\' => cow_start = ix,
+                                b'n' => {
+                                    buf.push('\n');
+                                    cow_start = ix + 1;
+                                }
+                                b'r' => {
+                                    buf.push('\r');
+                                    cow_start = ix + 1;
+                                }
+                                _ => {
+                                    if b >= b'0' && b <= b'3' && ix + 2 < s.len() {
+                                        // octal escape
+                                        let b1 = s.as_bytes()[ix + 1];
+                                        let b2 = s.as_bytes()[ix + 2];
+                                        if b1 >= b'0' && b1 <= b'7' && b2 >= b'0' && b2 <= b'7' {
+                                            let oct =
+                                                (b - b'0') * 64 + (b1 - b'0') * 8 + (b2 - b'0');
+                                            buf.push(oct as char);
+                                            ix += 2;
+                                            cow_start = ix + 1;
+                                        } else {
+                                            return Err(Error::UnknownEscape);
+                                        }
+                                    } else {
+                                        return Err(Error::UnknownEscape);
+                                    }
+                                }
+                            }
+                            ix += 1;
+                        }
+                        _ => ix += 1,
+                    }
+                }
+                Err(Error::UnclosedString)
+            }
+            _ => {
+                if is_alnum(b) {
+                    let mut ix = start + 1;
+                    while ix < s.len() {
+                        if !is_alnum(s.as_bytes()[ix]) {
+                            break;
+                        }
+                        ix += 1;
+                    }
+                    Ok((Token::Atom(&s[start..ix]), ix))
+                } else {
+                    Err(Error::UnexpectedChar(s[start..].chars().next().unwrap()))
+                }
+            }
+        }
+    }
+
+    fn try_into_string(self) -> Result<String, Error> {
+        match self {
+            Token::Atom(s) => Ok(s.into()),
+            Token::String(s) => Ok(s.into()),
+            _ => Err(Error::NotAString),
+        }
+    }
+
+    fn expect(s: &str, ix: usize, delim: u8) -> Option<usize> {
+        let ix = skip_ws(s, ix);
+        if ix < s.len() {
+            let b = s.as_bytes()[ix];
+            if b == delim {
+                return Some(ix + 1);
+            }
+        }
+        None
+    }
+}
+
+impl From<String> for Plist {
+    fn from(x: String) -> Plist {
+        Plist::String(x)
+    }
+}
+
+impl From<i64> for Plist {
+    fn from(x: i64) -> Plist {
+        Plist::Integer(x)
+    }
+}
+
+impl From<f64> for Plist {
+    fn from(x: f64) -> Plist {
+        Plist::Float(x)
+    }
+}
+
+impl From<Vec<Plist>> for Plist {
+    fn from(x: Vec<Plist>) -> Plist {
+        Plist::Array(x)
+    }
+}
+
+impl From<HashMap<String, Plist>> for Plist {
+    fn from(x: HashMap<String, Plist>) -> Plist {
+        Plist::Dictionary(x)
+    }
+}

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -116,12 +116,16 @@ impl Editor {
                     return None;
                 }
                 (crate::consts::GLYPHS_APP_PASTEBOARD_TYPE, Some(data)) => {
-                    crate::clipboard::from_glyphs_plist(data)
+                    match String::from_utf8(data) {
+                        Ok(s) => crate::clipboard::from_glyphs_plist_string(s),
+                        Err(e) => crate::clipboard::from_glyphs_plist(e.into_bytes()),
+                    }
                 }
                 _ => None,
             };
             if let Some(paths) = paths {
                 session.paste_paths(paths);
+                return Some(EditType::Normal);
             }
         }
 


### PR DESCRIPTION
This is a semi-accidental patch. It implements pasting data from
binary plists with the Glyphs.app style.

It does not actually work with stuff that is put on the clipboard
_by_ glyphs, because glyphs uses string plists, which the rust
plist library does not know how to parse.

However, it _does_ mean that you can copy and paste within the app,
so I think it's worth a commit just for that case. We can deal with
other formats at a later date.