### PR TITLE
Implement pasting of pdf data

### DIFF
--- a/src/design_space.rs
+++ b/src/design_space.rs
@@ -71,8 +71,7 @@ impl DPoint {
     /// Create a new `DPoint` from a `Point` in design space. This should only
     /// be used to convert back to a `DPoint` after using `Point` to do vector
     /// math in design space.
-    //TODO: don't expose these, implement the fns you need
-    fn from_raw(point: impl Into<Point>) -> DPoint {
+    pub fn from_raw(point: impl Into<Point>) -> DPoint {
         let point = point.into();
         DPoint::new(point.x.round(), point.y.round())
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -83,7 +83,7 @@ impl PointType {
 }
 
 impl PathPoint {
-    fn off_curve(path: usize, point: DPoint) -> PathPoint {
+    pub fn off_curve(path: usize, point: DPoint) -> PathPoint {
         let id = EntityId {
             parent: path,
             point: next_id(),
@@ -95,7 +95,7 @@ impl PathPoint {
         }
     }
 
-    fn on_curve(path: usize, point: DPoint) -> PathPoint {
+    pub fn on_curve(path: usize, point: DPoint) -> PathPoint {
         let id = EntityId {
             parent: path,
             point: next_id(),
@@ -142,6 +142,7 @@ impl Path {
         trailing: Option<DPoint>,
         closed: bool,
     ) -> Self {
+        assert!(!points.is_empty(), "path may not be empty");
         Path {
             id,
             points: Arc::new(points),
@@ -225,6 +226,7 @@ impl Path {
 
     /// Returns the start point of the path.
     pub fn start_point(&self) -> &PathPoint {
+        assert!(!self.points.is_empty(), "empty path is not constructable");
         if self.closed {
             self.points.last().unwrap()
         } else {

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -121,6 +121,7 @@ impl Editor {
                         Err(e) => crate::clipboard::from_glyphs_plist(e.into_bytes()),
                     }
                 }
+                (ClipboardFormat::PDF, Some(data)) => crate::clipboard::from_pdf_data(data),
                 _ => None,
             };
             if let Some(paths) = paths {


### PR DESCRIPTION
This gets PDF paste working. This was a bit of a headache, because
there's an odd behaviour on macOS where it seems that paths that
are both filled and stroked are included twice, the second time
after a matrix transformation. I'm sure there's a rationale for this,
but I couldn't find it, and so we apply these transforms as we
encounter them and then remove duplicate paths at the end.

----

I'd started this last week but had just left it sitting around, so figured its worth patching up and getting merged.