### PR TITLE
Fix crash when tangent point handle goes to bed

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -385,6 +385,10 @@ impl Path {
     /// to be adjusted.
     fn adjust_handle_angle(&mut self, bcp1: usize, on_curve: usize, bcp2: usize) {
         let raw_angle = (self.points[bcp1].point - self.points[on_curve].point).to_raw();
+        if raw_angle.hypot() == 0.0 {
+            return;
+        }
+
         // that angle is in the opposite direction, so flip it
         let norm_angle = raw_angle.normalize() * -1.0;
         let handle_len = (self.points[bcp2].point - self.points[on_curve].point)


### PR DESCRIPTION
When a tangent point handle was nudged onto the same coordinate as its
on curve point, we would crash when attempting to adjust the linked
off curve point; there was a division by zero leading to NaN.