### PR TITLE
Implement spacebar preview and barebones preview tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,10 +325,10 @@ dependencies = [
 [[package]]
 name = "druid"
 version = "0.4.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=324b38f#324b38f422bd95ba605d9b4cbabd8294d8498451"
+source = "git+https://github.com/xi-editor/druid.git?rev=37d49a3#37d49a364d3baf37c06542a9f9db4b582f21e21f"
 dependencies = [
- "druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=324b38f)",
- "druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=324b38f)",
+ "druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)",
+ "druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)",
  "fluent-bundle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-locale 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fluent-syntax 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.1.2"
-source = "git+https://github.com/xi-editor/druid.git?rev=324b38f#324b38f422bd95ba605d9b4cbabd8294d8498451"
+source = "git+https://github.com/xi-editor/druid.git?rev=37d49a3#37d49a364d3baf37c06542a9f9db4b582f21e21f"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.4.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=324b38f#324b38f422bd95ba605d9b4cbabd8294d8498451"
+source = "git+https://github.com/xi-editor/druid.git?rev=37d49a3#37d49a364d3baf37c06542a9f9db4b582f21e21f"
 dependencies = [
  "cairo-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1229,7 +1229,7 @@ dependencies = [
 name = "runebender"
 version = "0.2.0"
 dependencies = [
- "druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=324b38f)",
+ "druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lopdf 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "norad 0.1.0 (git+https://github.com/linebender/norad.git?rev=da3c755)",
@@ -1559,11 +1559,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum direct3d11 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "315aa929e68ba066cb6fb86f1b22af24f517e02fd9b5734c4d07e42cb9f4aefa"
 "checksum directwrite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8cdcd739e9351c411b8caf5cab32a27c818cfe06260595da121382ecdd22083d"
 "checksum druid 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfc2c5a80baa05c7e949e6f32c02846cca5f0e390b9deb43d24d9171ec730a0"
-"checksum druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=324b38f)" = "<none>"
+"checksum druid 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)" = "<none>"
 "checksum druid-derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa8d9846ac11feb8640aaf2fde998d57cd00d6c65f4d04a0bb025895f2076a5a"
-"checksum druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=324b38f)" = "<none>"
+"checksum druid-derive 0.1.2 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)" = "<none>"
 "checksum druid-shell 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b72f74db43368e53c26abc5587ccfdcb5d259b647f5fd322873eeef4f7c6f18"
-"checksum druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=324b38f)" = "<none>"
+"checksum druid-shell 0.4.0 (git+https://github.com/xi-editor/druid.git?rev=37d49a3)" = "<none>"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1639bbfd6765e92a40267d217a7acbac5b49320b68013f39a8e4376aa8c1e091"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,6 +34,17 @@ pub mod cmd {
     /// Sent when the 'pen' tool should be activated
     pub const PEN_TOOL: Selector = Selector::new("runebender.tool-pen");
 
+    /// Sent when the 'preview/hand' tool should be activated.
+    pub const PREVIEW_TOOL: Selector = Selector::new("runebender.tool-preview");
+
+    /// Sent when the preview tool is toggled  temporarily.
+    ///
+    /// This is normally bound to spacebar.
+    ///
+    /// The argument should be a bool indicating whether this is a keydown (true)
+    /// or a keyup (false).
+    pub const TOGGLE_PREVIEW_TOOL: Selector = Selector::new("runebender.tool-preview-toggle");
+
     /// Sent when the 'zoom in' menu item is selected
     pub const ZOOM_IN: Selector = Selector::new("runebender.zoom-in");
 

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -181,4 +181,11 @@ fn tools_menu<T: Data>() -> MenuDesc<T> {
             )
             .hotkey(SysMods::None, "p"),
         )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-preview-tool").with_placeholder("Preview".into()),
+                consts::cmd::PREVIEW_TOOL,
+            )
+            .hotkey(SysMods::None, "h"),
+        )
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,9 +1,11 @@
 //! A tool accepts user input and modifies the canvas.
 
 mod pen;
+mod preview;
 mod select;
 
 pub use pen::Pen;
+pub use preview::Preview;
 pub use select::Select;
 
 use crate::edit_session::EditSession;
@@ -91,6 +93,8 @@ pub trait Tool {
     ) -> Option<EditType> {
         None
     }
+
+    fn name(&self) -> &str;
 }
 
 impl EditType {

--- a/src/tools/pen.rs
+++ b/src/tools/pen.rs
@@ -87,6 +87,10 @@ impl Tool for Pen {
         mouse.mouse_event(event, data, self);
         self.this_edit_type.take()
     }
+
+    fn name(&self) -> &str {
+        "Pen"
+    }
 }
 
 /// Lock the smallest axis of `point` (from `prev`) to that axis on `prev`.

--- a/src/tools/preview.rs
+++ b/src/tools/preview.rs
@@ -1,0 +1,17 @@
+//! The 'preview' tool
+//!
+//! This is generally represented as the 'hand', and allows the user to pan around
+//! the workspace by clicking and dragging, although whether this makes sense
+//! in the era of the touchpad is an open question.
+
+use crate::tools::Tool;
+
+/// The state of the preview tool.
+#[derive(Debug, Default, Clone)]
+pub struct Preview {}
+
+impl Tool for Preview {
+    fn name(&self) -> &str {
+        "Preview"
+    }
+}

--- a/src/tools/select.rs
+++ b/src/tools/select.rs
@@ -97,6 +97,10 @@ impl Tool for Select {
         }
         self.this_edit_type.take()
     }
+
+    fn name(&self) -> &str {
+        "Select"
+    }
 }
 
 impl Select {

--- a/src/widgets/scroll_zoom.rs
+++ b/src/widgets/scroll_zoom.rs
@@ -3,8 +3,8 @@ use druid::piet::{Color, FontBuilder, RenderContext, Text, TextLayout, TextLayou
 use druid::kurbo::{Point, Rect, RoundedRect, Size, Vec2};
 use druid::widget::Scroll;
 use druid::{
-    BaseState, BoxConstraints, Env, Event, EventCtx, HotKey, LayoutCtx, PaintCtx, Selector,
-    UpdateCtx, Widget,
+    BaseState, BoxConstraints, Command, Env, Event, EventCtx, HotKey, KeyCode, LayoutCtx, PaintCtx,
+    Selector, UpdateCtx, Widget,
 };
 
 use crate::consts::CANVAS_SIZE;
@@ -215,6 +215,17 @@ impl<T: Widget<EditorState>> Widget<EditorState> for ScrollZoom<T> {
             }
             Event::KeyDown(k) if HotKey::new(None, "p").matches(k) => {
                 ctx.submit_command(cmd::PEN_TOOL, None)
+            }
+            Event::KeyDown(k) if HotKey::new(None, "h").matches(k) => {
+                ctx.submit_command(cmd::PREVIEW_TOOL, None)
+            }
+            Event::KeyDown(k) if !k.is_repeat && k.key_code == KeyCode::Space => {
+                let cmd = Command::new(cmd::TOGGLE_PREVIEW_TOOL, true);
+                ctx.submit_command(cmd, None);
+            }
+            Event::KeyUp(k) if k.key_code == KeyCode::Space => {
+                let cmd = Command::new(cmd::TOGGLE_PREVIEW_TOOL, false);
+                ctx.submit_command(cmd, None);
             }
             Event::MouseMoved(mouse) => {
                 self.mouse = mouse.pos;


### PR DESCRIPTION
This lets you use spacebar to toggle drawing the current glyph
in 'preview mode', that is with all outlines and components filled
and no other canvas entities visible.

<img width="706" alt="Screen Shot 2019-12-19 at 12 08 18 PM" src="https://user-images.githubusercontent.com/3330916/71205944-51057500-2258-11ea-960a-790a88b8d334.png">
<img width="706" alt="Screen Shot 2019-12-19 at 12 08 24 PM" src="https://user-images.githubusercontent.com/3330916/71205948-5662bf80-2258-11ea-9eb7-4cf7349d8a3d.png">
