### PR TITLE
Add EditableLabel widget, make advance editable

### DIFF
--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -85,6 +85,12 @@ impl EditSession {
         *Arc::make_mut(&mut self.glyph) = new_glyph;
     }
 
+    /// called if metadata changes elsewhere, such as in the main view.
+    pub fn update_glyph_metadata(&mut self, changed: &Arc<Glyph>) {
+        let glyph = Arc::make_mut(&mut self.glyph);
+        glyph.advance = changed.advance.clone();
+    }
+
     /// Returns the current layout bounds of the 'work', that is, all the things
     /// that are 'part of the glyph'.
     pub fn work_bounds(&self) -> Rect {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,4 +33,5 @@ pub fn configure_env(env: &mut Env) {
     env.set(druid::theme::LABEL_COLOR, Color::BLACK);
     env.set(druid::theme::WINDOW_BACKGROUND_COLOR, Color::WHITE);
     env.set(druid::theme::BACKGROUND_LIGHT, colors::LIGHT_GREY);
+    env.set(druid::theme::CURSOR_COLOR, Color::BLACK);
 }

--- a/src/widgets/editable_label.rs
+++ b/src/widgets/editable_label.rs
@@ -1,0 +1,191 @@
+// Copyright 2020 The xi-editor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A label that can be edited.
+//!
+//! This is a bit hacky, and depends on implementation details of other widgets.
+
+use druid::text::EditAction;
+use druid::widget::prelude::*;
+use druid::widget::{Label, LabelText, TextBox};
+use druid::{Command, Data, HotKey, KeyCode, Selector};
+
+// we send this to ourselves if another widget takes focus, in order
+// to validate and move out of editing mode
+//const LOST_FOCUS: Selector = Selector::new("druid.builtin.EditableLabel-lost-focus");
+const CANCEL_EDITING: Selector = Selector::new("druid.builtin.EditableLabel-cancel-editing");
+const COMPLETE_EDITING: Selector = Selector::new("druid.builtin.EditableLabel-complete-editing");
+
+/// A label with text that can be edited.
+///
+/// Edits are not applied to the data until editing finishes, usually when the
+/// user presses <return>. If the new text generates a valid value, it is set;
+/// otherwise editing continues.
+///
+/// Editing can be abandoned by pressing <esc>.
+pub struct EditableLabel<T> {
+    label: Label<T>,
+    buffer: String,
+    placeholder: String,
+    editing: bool,
+    text_box: TextBox,
+    on_completion: Box<dyn Fn(&str) -> Option<T>>,
+}
+
+impl<T: Data + std::fmt::Display + std::str::FromStr> EditableLabel<T> {
+    /// Create a new `EditableLabel` that uses `to_string` to display a value and
+    /// `FromStr` to validate the input.
+    pub fn parse() -> Self {
+        Self::new(|data: &T, _: &_| data.to_string(), |s| s.parse().ok())
+    }
+}
+
+impl<T: Data> EditableLabel<T> {
+    /// Create a new `EditableLabel`.
+    ///
+    /// The first argument creates a label; it should probably be a dynamic
+    /// or localized string.
+    ///
+    /// The second argument is a closure used to compute the data from the
+    /// contents of the string. This is called when the user presses return,
+    /// or otherwise tries to navigate away from the label; if it returns
+    /// `Some<T>` then that is set as the new data, and the edit ends. If it
+    /// returns `None`, then the edit continues.
+    pub fn new(
+        text: impl Into<LabelText<T>>,
+        on_completion: impl Fn(&str) -> Option<T> + 'static,
+    ) -> Self {
+        EditableLabel {
+            label: Label::new(text),
+            buffer: String::new(),
+            placeholder: String::new(),
+            text_box: TextBox::new(),
+            editing: false,
+            on_completion: Box::new(on_completion),
+        }
+    }
+
+    pub fn with_placeholder(mut self, text: impl Into<String>) -> Self {
+        self.placeholder = text.into();
+        self
+    }
+
+    fn complete(&mut self, ctx: &mut EventCtx, data: &mut T) {
+        if let Some(new) = (self.on_completion)(&self.buffer) {
+            *data = new;
+            self.editing = false;
+            ctx.request_layout();
+            ctx.resign_focus();
+        } else {
+            // don't tab away from here if we're editing
+            if !ctx.has_focus() {
+                ctx.request_focus();
+            }
+            ctx.submit_command(
+                Command::new(TextBox::PERFORM_EDIT, EditAction::SelectAll),
+                ctx.widget_id(),
+            );
+            // our content isn't valid
+            // ideally we would flash the background or something
+        }
+    }
+
+    fn cancel(&mut self, ctx: &mut EventCtx) {
+        self.editing = false;
+        ctx.request_layout();
+        ctx.resign_focus();
+    }
+
+    fn begin(&mut self, ctx: &mut EventCtx) {
+        self.editing = true;
+        self.buffer = self.label.text().to_string();
+        ctx.request_layout();
+    }
+}
+
+impl<T: Data> Widget<T> for EditableLabel<T> {
+    fn event(&mut self, ctx: &mut EventCtx, event: &Event, data: &mut T, env: &Env) {
+        if self.editing {
+            match event {
+                Event::Command(cmd) if cmd.selector == COMPLETE_EDITING => self.complete(ctx, data),
+                Event::KeyDown(k_e) if HotKey::new(None, KeyCode::Return).matches(k_e) => {
+                    ctx.set_handled();
+                    self.complete(ctx, data);
+                }
+                Event::Command(cmd) if cmd.selector == CANCEL_EDITING => self.cancel(ctx),
+                Event::KeyDown(k_e) if HotKey::new(None, KeyCode::Escape).matches(k_e) => {
+                    ctx.set_handled();
+                    self.cancel(ctx);
+                }
+                event => {
+                    self.text_box.event(ctx, event, &mut self.buffer, env);
+                    ctx.request_paint();
+                }
+            }
+        } else if let Event::MouseDown(_) = event {
+            self.begin(ctx);
+            self.text_box.event(ctx, event, &mut self.buffer, env);
+        }
+    }
+
+    fn lifecycle(&mut self, ctx: &mut LifeCycleCtx, event: &LifeCycle, data: &T, env: &Env) {
+        if let LifeCycle::WidgetAdded = event {
+            self.buffer = self.label.text().to_string();
+        }
+        self.label.lifecycle(ctx, event, data, env);
+        self.text_box.lifecycle(ctx, event, &self.buffer, env);
+
+        if let LifeCycle::FocusChanged(focus) = event {
+            // if the user focuses elsewhere, we need to reset ourselves
+            if !focus {
+                ctx.submit_command(COMPLETE_EDITING, None);
+            } else if !self.editing {
+                self.editing = true;
+                self.buffer = self.label.text().to_string();
+                ctx.request_layout();
+            }
+        }
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx, old_data: &T, data: &T, env: &Env) {
+        // what should this do? If we're editing, does it cancel our editing? No.
+        if !self.editing {
+            self.label.update(ctx, old_data, data, env);
+        } else {
+            self.editing = false;
+            ctx.request_layout();
+        }
+        // we don't update the textbox because we don't bother keeping the old
+        // data. If the implementation of textbox changes, though, we would break?
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints, data: &T, env: &Env) -> Size {
+        let textbox_size = self.text_box.layout(ctx, bc, &self.buffer, env);
+        let label_constraints = BoxConstraints::new(textbox_size, bc.max());
+        if self.editing {
+            textbox_size
+        } else {
+            // label should be at least as large as textbox
+            self.label.layout(ctx, &label_constraints, data, env)
+        }
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &T, env: &Env) {
+        if self.editing {
+            self.text_box.paint(ctx, &self.buffer, env);
+        } else {
+            self.label.paint(ctx, data, env);
+        }
+    }
+}

--- a/src/widgets/maybe.rs
+++ b/src/widgets/maybe.rs
@@ -84,12 +84,12 @@ impl<T: Data> Widget<Option<T>> for Maybe<T> {
         data: &Option<T>,
         env: &Env,
     ) {
-        if let LifeCycle::WidgetAdded = event {
-            if data.is_some() != self.widget.is_some() {
-                // only possible at launch, because we default to `Some`
-                self.rebuild_widget(data.is_some());
-            }
+        if data.is_some() != self.widget.is_some() {
+            // possible if getting lifecycle after an event that changed the data,
+            // or on WidgetAdded
+            self.rebuild_widget(data.is_some());
         }
+        assert_eq!(data.is_some(), self.widget.is_some(), "{:?}", event);
         match data.as_ref() {
             Some(d) => self.widget.unwrap_some().lifecycle(ctx, event, d, env),
             None => self

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,6 +1,7 @@
 //! Druid `Widget`s.
 
 mod controller;
+mod editable_label;
 mod editor;
 mod grid;
 mod maybe;
@@ -8,6 +9,7 @@ mod scroll_zoom;
 mod sidebar;
 
 pub use controller::Controller;
+pub use editable_label::EditableLabel;
 pub use editor::Editor;
 pub use grid::GlyphGrid;
 use maybe::Maybe;

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -10,7 +10,7 @@ use druid::widget::{Flex, Label, SizedBox, WidgetExt};
 
 use crate::data::{lenses, GlyphPlus, Workspace};
 use crate::theme;
-use crate::widgets::Maybe;
+use crate::widgets::{EditableLabel, Maybe};
 
 const SELECTED_GLYPH_BOTTOM_PADDING: f64 = 10.0;
 const SELECTED_GLYPH_HEIGHT: f64 = 220.0;
@@ -42,13 +42,11 @@ fn selected_glyph_widget() -> impl Widget<GlyphPlus> {
             .lens(lenses::app_state::Codepoint),
         )
         .with_flex_child(SelectedGlyph::new(), 1.0)
-        .with_child(Label::new(|d: &GlyphPlus, _: &Env| {
-            d.glyph
-                .advance
-                .as_ref()
-                .map(|a| a.width.to_string())
-                .unwrap_or("___".into())
-        }))
+        .with_child(
+            EditableLabel::parse()
+                .fix_width(45.)
+                .lens(lenses::app_state::Advance),
+        )
         .with_child(
             Flex::row()
                 .with_child(


### PR DESCRIPTION
This will be a useful widget in a bunch of places; the first of
these is editing a glyph's advance in the main screen. The next
will be editing the coordinate of a point.

![Screen Shot 2020-04-15 at 4 35 49 PM](https://user-images.githubusercontent.com/3330916/79385814-2c37ba80-7f37-11ea-8f2b-8c9122e248c1.png)
