### PR TITLE
Add and delete glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=cb96b750#cb96b750c420b2de6729b8b915c06f734c4ffab0"
+source = "git+https://github.com/xi-editor/druid.git?rev=1384e6cd#1384e6cdea7793dc95cc6774aeb6789015c6cad9"
 dependencies = [
  "console_log",
  "druid-derive 0.4.0",
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.4.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=cb96b750#cb96b750c420b2de6729b8b915c06f734c4ffab0"
+source = "git+https://github.com/xi-editor/druid.git?rev=1384e6cd#1384e6cdea7793dc95cc6774aeb6789015c6cad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/xi-editor/druid.git?rev=cb96b750#cb96b750c420b2de6729b8b915c06f734c4ffab0"
+source = "git+https://github.com/xi-editor/druid.git?rev=1384e6cd#1384e6cdea7793dc95cc6774aeb6789015c6cad9"
 dependencies = [
  "cairo-rs",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 norad = { version = "0.1.0", features = ["druid"] }
-druid = { git = "https://github.com/xi-editor/druid.git", rev = "cb96b750", version = "0.6" }
+druid = { git = "https://github.com/xi-editor/druid.git", rev = "1384e6cd", version = "0.6" }
 log = "0.4.8"
 plist = "0.5"
 serde = "1.0"

--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -51,6 +51,18 @@ impl AppDelegate<AppState> for Delegate {
                 }
                 false
             }
+
+            consts::cmd::NEW_GLYPH => {
+                let new_glyph_name = data.workspace.add_new_glyph();
+                data.workspace.selected = Some(new_glyph_name);
+                false
+            }
+
+            consts::cmd::DELETE_SELECTED_GLYPH => {
+                data.workspace.delete_selected_glyph();
+                false
+            }
+
             EDIT_GLYPH => {
                 let payload = cmd
                     .get_object::<GlyphName>()

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -25,6 +25,12 @@ pub mod cmd {
     /// sent by the 'deselect' menu item
     pub const DESELECT_ALL: Selector = Selector::new("runebender.deselect-all");
 
+    /// sent by the 'new glyph' menu item
+    pub const NEW_GLYPH: Selector = Selector::new("runebender.new-glyph");
+
+    /// sent by the 'delete glyph' menu item
+    pub const DELETE_SELECTED_GLYPH: Selector = Selector::new("runebender.delete-selected-glyph");
+
     /// sent by the 'add component' menu item
     pub const ADD_COMPONENT: Selector = Selector::new("runebender.add-component");
 

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -5,7 +5,8 @@ use druid::kurbo::Point;
 use druid::commands;
 use druid::platform_menus;
 use druid::{
-    Command, Data, FileDialogOptions, FileSpec, LocalizedString, MenuDesc, MenuItem, SysMods,
+    Command, Data, FileDialogOptions, FileSpec, KeyCode, LocalizedString, MenuDesc, MenuItem,
+    SysMods,
 };
 
 use crate::consts;
@@ -45,7 +46,7 @@ pub(crate) fn make_menu(data: &AppState) -> MenuDesc<AppState> {
     menu.append(file_menu(data))
         .append(edit_menu())
         .append(view_menu())
-        .append(glyph_menu())
+        .append(glyph_menu(data))
         .append(tools_menu())
 }
 
@@ -153,15 +154,31 @@ fn view_menu<T: Data>() -> MenuDesc<T> {
         )
 }
 
-fn glyph_menu<T: Data>() -> MenuDesc<T> {
-    MenuDesc::new(LocalizedString::new("menu-glyph-menu").with_placeholder("Glyph")).append(
-        MenuItem::new(
-            LocalizedString::new("menu-item-add-component").with_placeholder("Add Component"),
-            consts::cmd::ADD_COMPONENT,
+fn glyph_menu(data: &AppState) -> MenuDesc<AppState> {
+    MenuDesc::new(LocalizedString::new("menu-glyph-menu").with_placeholder("Glyph"))
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-new-glyph").with_placeholder("New Glyph"),
+                consts::cmd::NEW_GLYPH,
+            )
+            .hotkey(SysMods::CmdShift, "n"),
         )
-        .hotkey(SysMods::CmdShift, "c")
-        .disabled(),
-    )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-delete-glyph").with_placeholder("Delete Glyph"),
+                consts::cmd::DELETE_SELECTED_GLYPH,
+            )
+            .hotkey(SysMods::Cmd, KeyCode::Backspace)
+            .disabled_if(|| data.workspace.selected.is_none()),
+        )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-add-component").with_placeholder("Add Component"),
+                consts::cmd::ADD_COMPONENT,
+            )
+            .hotkey(SysMods::CmdShift, "c")
+            .disabled(),
+        )
 }
 
 fn tools_menu<T: Data>() -> MenuDesc<T> {

--- a/src/widgets/controller.rs
+++ b/src/widgets/controller.rs
@@ -1,7 +1,7 @@
 //! Controller widgets
 
 use druid::widget::Controller;
-use druid::{Command, Env, Event, EventCtx, Widget};
+use druid::{Command, Env, Event, EventCtx, UpdateCtx, Widget};
 
 use crate::consts;
 use crate::data::AppState;
@@ -28,5 +28,21 @@ impl<W: Widget<AppState>> Controller<AppState, W> for RootWindowController {
             }
             other => child.event(ctx, other, data, env),
         }
+    }
+
+    fn update(
+        &mut self,
+        child: &mut W,
+        ctx: &mut UpdateCtx,
+        old_data: &AppState,
+        data: &AppState,
+        env: &Env,
+    ) {
+        if old_data.workspace.selected.is_none() != data.workspace.selected.is_none() {
+            let menu = menus::make_menu(data);
+            let cmd = Command::new(druid::commands::SET_MENU, menu);
+            ctx.submit_command(cmd, None);
+        }
+        child.update(ctx, old_data, data, env);
     }
 }


### PR DESCRIPTION
This adds the ability to create and delete glyphs in the main view.
This is available via commands in the 'Glyph' menu.

Deleting glyphs cannot currently be undone!