### PR TITLE
Don't use GlyphName to identify edit sessions

### DIFF
--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -75,7 +75,7 @@ impl AppDelegate<AppState> for Delegate {
                         ctx.submit_command(command, *id);
                     }
                     None => {
-                        let session = get_or_create_session(&payload, data);
+                        let session = data.workspace.get_or_create_session(&payload);
                         let new_win = WindowDesc::new(move || make_editor(&session))
                             .title(LocalizedString::new("").with_placeholder(payload.to_string()))
                             .window_size(Size::new(900.0, 800.0))
@@ -119,20 +119,8 @@ impl AppDelegate<AppState> for Delegate {
     }
 }
 
-fn get_or_create_session(name: &GlyphName, data: &mut AppState) -> Arc<EditSession> {
-    data.workspace
-        .sessions
-        .get(name)
-        .cloned()
-        .unwrap_or_else(|| {
-            let session = Arc::new(EditSession::new(name, &data.workspace));
-            Arc::make_mut(&mut data.workspace.sessions).insert(name.clone(), session.clone());
-            session
-        })
-}
-
 fn make_editor(session: &Arc<EditSession>) -> impl Widget<AppState> {
     ScrollZoom::new(Editor::new(session.clone()))
-        .lens(AppState::workspace.then(lenses::app_state::EditorState(session.name.clone())))
+        .lens(AppState::workspace.then(lenses::app_state::EditorState(session.id)))
         .controller(RootWindowController::default())
 }

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -17,9 +17,24 @@ use crate::path::{EntityId, Path, PathPoint};
 //TODO: this doesn't feel very robust; items themselves should have hitzones?
 pub const MIN_CLICK_DISTANCE: f64 = 10.0;
 
+/// A unique identifier for a session. A session keeps the same identifier
+/// even if the name of the glyph changes.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct SessionId(usize);
+
+impl SessionId {
+    fn next() -> SessionId {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        SessionId(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 /// The editing state of a particular glyph.
 #[derive(Debug, Clone, Data)]
 pub struct EditSession {
+    #[data(ignore)]
+    pub id: SessionId,
     pub name: GlyphName,
     pub glyph: Arc<Glyph>,
     pub paths: Arc<Vec<Path>>,
@@ -59,6 +74,7 @@ impl EditSession {
             .unwrap_or_default();
 
         EditSession {
+            id: SessionId::next(),
             name,
             glyph,
             paths: Arc::new(paths),


### PR DESCRIPTION
Doing so makes it hard to rename a glyph that is being edited.
Here we introduce a SessionId and another level of indirection
to track sessions across renames.