### PR TITLE
Calculate glyph codepoints based on name

### DIFF
--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -63,6 +63,14 @@ impl AppDelegate<AppState> for Delegate {
                 false
             }
 
+            consts::cmd::RENAME_GLYPH => {
+                let consts::cmd::RenameGlyphArgs { old, new } = cmd
+                    .get_object()
+                    .expect("RENAME_GLYPH has incorrect payload");
+                data.workspace.rename_glyph(old.clone(), new.clone());
+                false
+            }
+
             EDIT_GLYPH => {
                 let payload = cmd
                     .get_object::<GlyphName>()

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -10,6 +10,7 @@ pub const GLYPHS_APP_PASTEBOARD_TYPE: FormatId = "Glyphs elements pasteboard typ
 pub mod cmd {
     use druid::kurbo::Point;
     use druid::Selector;
+    use norad::GlyphName;
 
     use crate::path::EntityId;
 
@@ -30,6 +31,17 @@ pub mod cmd {
 
     /// sent by the 'delete glyph' menu item
     pub const DELETE_SELECTED_GLYPH: Selector = Selector::new("runebender.delete-selected-glyph");
+
+    /// Sent to the root to rename a glyph.
+    ///
+    /// The arguments **must** be a `RenameGlyphArgs`
+    pub const RENAME_GLYPH: Selector = Selector::new("runebender.rename-glyph");
+
+    /// Arguments passed with the RENAME_GLYPH command.
+    pub struct RenameGlyphArgs {
+        pub old: GlyphName,
+        pub new: GlyphName,
+    }
 
     /// sent by the 'add component' menu item
     pub const ADD_COMPONENT: Selector = Selector::new("runebender.add-component");

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -108,7 +108,9 @@ impl EditSession {
 
     pub fn rename(&mut self, name: GlyphName) {
         self.name = name.clone();
-        Arc::make_mut(&mut self.glyph).name = name;
+        let glyph = Arc::make_mut(&mut self.glyph);
+        glyph.codepoints = crate::glyph_names::codepoints_for_glyph(&name);
+        glyph.name = name;
     }
 
     /// Returns the current layout bounds of the 'work', that is, all the things

--- a/src/glyph_names.rs
+++ b/src/glyph_names.rs
@@ -44,6 +44,17 @@ pub fn validate_and_standardize_name(name: &str) -> Result<String, IllegalName> 
     }
 }
 
+/// Given a glyph name, guess what the unicode value is?
+///
+/// Works fine for known glyph names, otherwise just uses the first character :shrug:
+pub fn codepoints_for_glyph(name: &str) -> Option<Vec<char>> {
+    if let Some(chr) = GLYPH_NAMES.iter().find(|(_, n)| *n == name).map(|(c, _)| c) {
+        Some(vec![*chr])
+    } else {
+        name.chars().next().map(|c| vec![c])
+    }
+}
+
 /// An error indicating a name included illegal characters.
 #[derive(Clone)]
 pub struct IllegalName;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,10 +116,14 @@ fn create_blank_font() -> norad::Ufo {
     let A_ = 'A' as u32;
 
     let layer = ufo.get_default_layer_mut().unwrap();
-    (0..25)
+    (0..26)
         .map(|i| std::char::from_u32(a_ + i).unwrap())
-        .chain((0..25).map(|i| std::char::from_u32(A_ + i).unwrap()))
-        .map(|chr| norad::Glyph::new_named(chr.to_string()))
+        .chain((0..26).map(|i| std::char::from_u32(A_ + i).unwrap()))
+        .map(|chr| {
+            let mut glyph = norad::Glyph::new_named(chr.to_string());
+            glyph.codepoints = Some(vec![chr]);
+            glyph
+        })
         .for_each(|glyph| layer.insert_glyph(glyph));
     ufo
 }


### PR DESCRIPTION
This uses the aglfn list to map from names to codepoints, and
if a name does not exist it just uses the first character in
the name. Which is not correct! totally not okay! But also maybe
the least bad thing to do, for now.

This also reworks how we actually do renaming; previously we were
doing some very fancy lens stuff, but I think it's easier to just
use a command for this.