### PR TITLE
Be less aggressive when guessing codepoints from a name

### DIFF
--- a/src/glyph_names.rs
+++ b/src/glyph_names.rs
@@ -48,14 +48,18 @@ pub fn validate_and_standardize_name(name: &str) -> Result<String, IllegalName> 
 ///
 /// Works fine for known glyph names, otherwise just uses the first character :shrug:
 pub fn codepoints_for_glyph(name: &str) -> Option<Vec<char>> {
-    if let Some(chr) = GLYPH_NAMES.iter().find(|(_, n)| *n == name).map(|(c, _)| c) {
-        Some(vec![*chr])
-    } else if name.chars().nth(1).is_none() {
-        // if we're at most one char long, use that as our codepoint
-        name.chars().next().map(|c| vec![c])
-    } else {
-        None
-    }
+    GLYPH_NAMES
+        .iter()
+        .find(|(_, n)| *n == name)
+        .map(|(c, _)| vec![*c])
+        .or_else(|| {
+            let mut chars = name.chars();
+            // if we're at most one char long, use that as our codepoint
+            match (chars.next(), chars.next()) {
+                (Some(c), None) => Some(vec![c]),
+                _ => None,
+            }
+        })
 }
 
 /// An error indicating a name included illegal characters.

--- a/src/glyph_names.rs
+++ b/src/glyph_names.rs
@@ -50,8 +50,11 @@ pub fn validate_and_standardize_name(name: &str) -> Result<String, IllegalName> 
 pub fn codepoints_for_glyph(name: &str) -> Option<Vec<char>> {
     if let Some(chr) = GLYPH_NAMES.iter().find(|(_, n)| *n == name).map(|(c, _)| c) {
         Some(vec![*chr])
-    } else {
+    } else if name.chars().nth(1).is_none() {
+        // if we're at most one char long, use that as our codepoint
         name.chars().next().map(|c| vec![c])
+    } else {
+        None
     }
 }
 
@@ -90,6 +93,13 @@ mod tests {
         assert_eq!(glyph_name_for_char('<'), Some("less"));
         assert_eq!(glyph_name_for_glyph("ء"), None);
         assert_eq!(glyph_name_for_glyph("!"), Some("exclam"));
+    }
+
+    #[test]
+    fn codepoints_for_glyph_() {
+        assert_eq!(codepoints_for_glyph("A"), Some(vec!['A']));
+        assert_eq!(codepoints_for_glyph("eacute"), Some(vec!['é']));
+        assert_eq!(codepoints_for_glyph("some-string"), None);
     }
 
     #[test]


### PR DESCRIPTION
Noticed this while drawing the icons; I do not want a glyph named
'Arrow' to automatically be assigned to 'A' :grin: