### PR TITLE
Always backup an existing file before overwriting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "norad"
 version = "0.1.0"
-source = "git+https://github.com/linebender/norad.git?rev=0a18f6c#0a18f6c419060375b68df8d86ab86a871e010fae"
+source = "git+https://github.com/linebender/norad.git?rev=50ab469#50ab469fe8b7e77e425d94f4b2bf6e67410fef4a"
 dependencies = [
  "druid",
  "plist 1.0.0",
@@ -1364,6 +1364,7 @@ dependencies = [
 name = "runebender"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "druid",
  "log",
  "lopdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-norad = { git = "https://github.com/linebender/norad.git", rev = "0a18f6c", features = ["druid"] }
+norad = { git = "https://github.com/linebender/norad.git", rev = "50ab469", features = ["druid"] }
 druid = { git = "https://github.com/xi-editor/druid.git", rev = "7fab0485", version = "0.6" }
 log = "0.4.8"
 plist = "0.5"
@@ -14,3 +14,4 @@ serde = "1.0"
 serde_derive = "1.0"
 lopdf = "0.24.0"
 svg = "0.7.1"
+chrono = "0.4"


### PR DESCRIPTION
Saving isn't well tested at the moment and so it seems best to
be maximally cautious about user data.

This moves to moving any existing data before overwriting.
Given a file ./path/to/font.ufo, backups will be created at
./path/to/font_backups/YYYY-MM-DD_HHMMSS.ufo.

saves that occur in the same second may still cause data loss?