### PR TITLE
Bezcache

### DIFF
--- a/src/bez_cache.rs
+++ b/src/bez_cache.rs
@@ -1,0 +1,230 @@
+//! A mapping of component ids to glyphs that contain that id
+//!
+//! this is used to invalidate glyphs appropriately when components change
+
+use std::borrow::Cow;
+//use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use druid::kurbo::{Affine, BezPath};
+use druid::Data;
+use norad::{Glyph, GlyphName, Ufo};
+
+const PRE_CACHE_SIZE: usize = 8;
+
+/// A cache of up to date paths for each glyph.
+///
+/// This plays nicely with `Data` by employing a cheap-to-clone pre-cache
+/// layer that will prevent needing to actually query the hashmap too often.
+#[derive(Debug, Clone, Default, Data)]
+pub(crate) struct BezCache {
+    beziers: Arc<HashMap<GlyphName, Arc<BezPath>>>,
+    pre_cache: PreCache,
+    components: ComponentMap,
+}
+
+/// Tracks what glyphs are used as components in what other glyphs
+#[derive(Debug, Clone, Data, Default)]
+pub(crate) struct ComponentMap {
+    inner: Arc<HashMap<GlyphName, Vec<GlyphName>>>,
+}
+
+/// a small array of cache entries to prevent unnecessary cloning
+#[derive(Debug, Clone, Default, Data)]
+struct PreCache {
+    store: [Option<(GlyphName, Arc<BezPath>)>; PRE_CACHE_SIZE],
+    len: usize,
+}
+impl PreCache {
+    fn is_full(&self) -> bool {
+        self.len == PRE_CACHE_SIZE
+    }
+
+    #[inline]
+    fn idx_for_key(&self, key: &GlyphName) -> Option<usize> {
+        self.store.iter().flatten().position(|item| item.0 == *key)
+    }
+
+    fn get(&self, key: &GlyphName) -> Option<Arc<BezPath>> {
+        self.idx_for_key(key)
+            .map(|idx| self.store[idx].as_ref().unwrap().1.clone())
+    }
+
+    fn remove(&mut self, key: &GlyphName) {
+        if let Some(idx) = self.idx_for_key(key) {
+            let last_idx = self.len - 1;
+            self.store.swap(idx, last_idx);
+            self.store[last_idx] = None;
+            self.len -= 1;
+            if self.store.iter().take(self.len).any(Option::is_none) {
+                panic!("remove failed, idx {} last_idx {}", idx, last_idx);
+            }
+        }
+    }
+
+    /// If the item cannot be inserted, it is returned in the error.
+    fn try_insert(
+        &mut self,
+        key: GlyphName,
+        value: Arc<BezPath>,
+    ) -> Result<(), (GlyphName, Arc<BezPath>)> {
+        match self.idx_for_key(&key) {
+            Some(idx) => self.store[idx] = Some((key, value)),
+            None if self.is_full() => return Err((key, value)),
+            None => {
+                assert!(!self.is_full());
+                self.store[self.len] = Some((key, value));
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn drain(&mut self) -> impl Iterator<Item = (GlyphName, Arc<BezPath>)> {
+        let items = std::mem::take(&mut self.store);
+        let len = self.len;
+        self.len = 0;
+        let mut idx = 0;
+        std::iter::from_fn(move || {
+            if idx == len {
+                None
+            } else {
+                idx += 1;
+                assert!(items[idx - 1].as_ref().is_some(), "idx {} len {}", idx, len);
+                Some(items[idx - 1].as_ref().unwrap().clone())
+            }
+        })
+    }
+}
+
+impl BezCache {
+    pub(crate) fn reset<'a, F>(&mut self, ufo: &Ufo, getter: &'a F)
+    where
+        F: Fn(&GlyphName) -> Option<&'a Arc<Glyph>> + 'a,
+    {
+        self.components = ComponentMap::new(ufo);
+        self.pre_cache = Default::default();
+        for name in ufo.iter_names() {
+            self.rebuild_without_inval(&name, getter);
+        }
+    }
+
+    pub(crate) fn get(&self, name: &GlyphName) -> Option<Arc<BezPath>> {
+        self.pre_cache
+            .get(name)
+            .or_else(|| self.beziers.get(name).cloned())
+    }
+
+    pub(crate) fn set(&mut self, name: GlyphName, path: Arc<BezPath>) {
+        let result = self.pre_cache.try_insert(name, path);
+        // we need to actually hit the main cache
+        if let Err((name, path)) = result {
+            let cache = Arc::make_mut(&mut self.beziers);
+            cache.insert(name, path);
+            cache.extend(self.pre_cache.drain());
+        }
+    }
+
+    pub(crate) fn invalidate(&mut self, name: &GlyphName) {
+        let cache = Arc::make_mut(&mut self.beziers);
+        for glyph in self.components.glyphs_containing_component(name).iter() {
+            self.pre_cache.remove(glyph);
+            cache.remove(glyph);
+        }
+    }
+
+    pub(crate) fn rebuild<'a, F>(
+        &mut self,
+        name: &GlyphName,
+        glyph_getter: &'a F,
+    ) -> Option<Arc<BezPath>>
+    where
+        F: Fn(&GlyphName) -> Option<&'a Arc<Glyph>> + 'a,
+    {
+        self.invalidate(name);
+        self.rebuild_without_inval(name, glyph_getter)
+    }
+
+    pub fn rebuild_without_inval<'a, F>(
+        &mut self,
+        name: &GlyphName,
+        glyph_getter: &'a F,
+    ) -> Option<Arc<BezPath>>
+    where
+        F: Fn(&GlyphName) -> Option<&'a Arc<Glyph>> + 'a,
+    {
+        let glyph = glyph_getter(name)?;
+        let mut path = crate::data::path_for_glyph(glyph)?;
+
+        for comp in glyph
+            .outline
+            .as_ref()
+            .iter()
+            .flat_map(|o| o.components.iter())
+        {
+            match self.rebuild_without_inval(&comp.base, glyph_getter) {
+                Some(component) => {
+                    let affine: Affine = comp.transform.clone().into();
+                    for comp_elem in (affine * &*component).elements() {
+                        path.push(*comp_elem);
+                    }
+                }
+                None => log::warn!("missing component {} in glyph {}", comp.base, glyph.name),
+            }
+        }
+        let path = Arc::new(path);
+        self.set(name.clone(), path.clone());
+        Some(path)
+    }
+
+    pub(crate) fn glyphs_containing_component<'a>(
+        &'a self,
+        name: &GlyphName,
+    ) -> Cow<'a, [GlyphName]> {
+        self.components.glyphs_containing_component(name)
+    }
+}
+
+impl ComponentMap {
+    fn new(ufo: &Ufo) -> Self {
+        let mut lookup: HashMap<GlyphName, Vec<GlyphName>> = HashMap::new();
+        for name in ufo.iter_names() {
+            if let Some(glyph) = ufo.get_glyph(&name) {
+                for component in glyph
+                    .outline
+                    .as_ref()
+                    .iter()
+                    .flat_map(|o| o.components.iter())
+                {
+                    lookup
+                        .entry(component.base.clone())
+                        .or_default()
+                        .push(name.clone());
+                }
+            }
+        }
+
+        ComponentMap {
+            inner: Arc::new(lookup),
+        }
+    }
+
+    fn glyphs_containing_component<'a>(&'a self, name: &GlyphName) -> Cow<'a, [GlyphName]> {
+        if let Some(glyphs) = self.inner.get(name) {
+            let mut component_children = glyphs
+                .iter()
+                .flat_map(|g| self.inner.get(g))
+                .flat_map(|g| g.iter().cloned())
+                .collect::<Vec<_>>();
+            if component_children.is_empty() {
+                Cow::Borrowed(glyphs.as_slice())
+            } else {
+                component_children.extend_from_slice(glyphs);
+                Cow::Owned(component_children)
+            }
+        } else {
+            Cow::Owned(Vec::new())
+        }
+    }
+}

--- a/src/bez_cache.rs
+++ b/src/bez_cache.rs
@@ -3,7 +3,6 @@
 //! this is used to invalidate glyphs appropriately when components change
 
 use std::borrow::Cow;
-//use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -151,7 +150,7 @@ impl BezCache {
         self.rebuild_without_inval(name, glyph_getter)
     }
 
-    pub fn rebuild_without_inval<'a, F>(
+    fn rebuild_without_inval<'a, F>(
         &mut self,
         name: &GlyphName,
         glyph_getter: &'a F,

--- a/src/bez_cache.rs
+++ b/src/bez_cache.rs
@@ -36,6 +36,7 @@ struct PreCache {
     store: [Option<(GlyphName, Arc<BezPath>)>; PRE_CACHE_SIZE],
     len: usize,
 }
+
 impl PreCache {
     fn is_full(&self) -> bool {
         self.len == PRE_CACHE_SIZE
@@ -47,8 +48,12 @@ impl PreCache {
     }
 
     fn get(&self, key: &GlyphName) -> Option<Arc<BezPath>> {
-        self.idx_for_key(key)
-            .map(|idx| self.store[idx].as_ref().unwrap().1.clone())
+        self.store
+            .iter()
+            .flatten()
+            .find(|item| &item.0 == key)
+            .map(|(_, bez)| bez)
+            .cloned()
     }
 
     fn remove(&mut self, key: &GlyphName) {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -297,11 +297,11 @@ impl<'a, 'b: 'a> DrawCtx<'a, 'b> {
     }
 
     fn draw_component(&mut self, component: &Component, font: &Workspace, color: Color) {
-        if let Some(bez) = font.get_bezier(&component.base) {
-            let mut bez = Arc::try_unwrap(bez).expect("just created, guaranteed unique");
+        if let Some(mut bez) = font.get_bezier(&component.base) {
+            let bez = Arc::make_mut(&mut bez);
             bez.apply_affine(component.transform);
             bez.apply_affine(self.space.affine());
-            self.fill(bez, &color);
+            self.fill(&*bez, &color);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate serde_derive;
 extern crate lopdf;
 
 mod app_delegate;
+mod bez_cache;
 mod clipboard;
 mod component;
 mod consts;

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -10,7 +10,7 @@ use druid::widget::{Controller, Flex, Label, SizedBox, WidgetExt};
 
 use norad::GlyphName;
 
-use crate::data::{lenses, GlyphPlus, Workspace};
+use crate::data::{lenses, SelectedGlyph, Workspace};
 use crate::theme;
 use crate::widgets::{EditableLabel, Maybe};
 
@@ -23,7 +23,7 @@ pub struct Sidebar {
     selected_glyph: WidgetPod<Workspace, Box<dyn Widget<Workspace>>>,
 }
 
-fn selected_glyph_widget() -> impl Widget<GlyphPlus> {
+fn selected_glyph_widget() -> impl Widget<SelectedGlyph> {
     Flex::column()
         .with_child(
             EditableLabel::new(
@@ -52,7 +52,7 @@ fn selected_glyph_widget() -> impl Widget<GlyphPlus> {
             )
             .lens(lenses::app_state::Codepoint),
         )
-        .with_flex_child(SelectedGlyph::new(), 1.0)
+        .with_flex_child(GlyphPainter::new(), 1.0)
         .with_child(
             EditableLabel::parse()
                 .fix_width(45.)
@@ -143,29 +143,36 @@ impl Widget<Workspace> for Sidebar {
 }
 
 // currently just paints the glyph shape
-struct SelectedGlyph {}
+struct GlyphPainter;
 
-impl SelectedGlyph {
+impl GlyphPainter {
     pub fn new() -> Self {
-        SelectedGlyph {}
+        GlyphPainter
     }
 }
 
-impl Widget<GlyphPlus> for SelectedGlyph {
-    fn event(&mut self, _ctx: &mut EventCtx, _event: &Event, _data: &mut GlyphPlus, _env: &Env) {}
+impl Widget<SelectedGlyph> for GlyphPainter {
+    fn event(
+        &mut self,
+        _ctx: &mut EventCtx,
+        _event: &Event,
+        _data: &mut SelectedGlyph,
+        _env: &Env,
+    ) {
+    }
     fn lifecycle(
         &mut self,
         _ctx: &mut LifeCycleCtx,
         _event: &LifeCycle,
-        _data: &GlyphPlus,
+        _data: &SelectedGlyph,
         _env: &Env,
     ) {
     }
     fn update(
         &mut self,
         _ctx: &mut UpdateCtx,
-        _old_data: &GlyphPlus,
-        _data: &GlyphPlus,
+        _old_data: &SelectedGlyph,
+        _data: &SelectedGlyph,
         _env: &Env,
     ) {
     }
@@ -173,14 +180,14 @@ impl Widget<GlyphPlus> for SelectedGlyph {
         &mut self,
         _ctx: &mut LayoutCtx,
         bc: &BoxConstraints,
-        _data: &GlyphPlus,
+        _data: &SelectedGlyph,
         _env: &Env,
     ) -> Size {
         let width = bc.max().width;
         bc.constrain(Size::new(width, SELECTED_GLYPH_HEIGHT))
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, data: &GlyphPlus, env: &Env) {
+    fn paint(&mut self, ctx: &mut PaintCtx, data: &SelectedGlyph, env: &Env) {
         let advance = data
             .glyph
             .advance


### PR DESCRIPTION
This is an attempt to recompute the paths of glyphs only when needed;
without this patch (or something similar) performance degrades
significantly when opening fonts like NotoCJK.


There are some problems with our architecture that we'll need to address at some point, and this solution isn't ideal. My current feeling around a bunch of this stuff is that we're exploring the space and some shortcuts are okay right now, since a lot of this stuff is going to need to get reworked in bigger ways down the road.
