### PR TITLE
added some more i18n strings for German and made some buttons and labels into LocalizedString in the process

### DIFF
--- a/resources/i18n/de-DE/builtin.ftl
+++ b/resources/i18n/de-DE/builtin.ftl
@@ -1,0 +1,73 @@
+-app-name = Runebender
+
+# The 'application' menu on macOS
+macos-menu-about-app = Über { -app-name }
+macos-menu-preferences = Einstellungen...
+macos-menu-hide-app = { -app-name } ausblenden
+macos-menu-hide-others = Andere ausblenden
+macos-menu-show-all = Alle einblenden
+macos-menu-services = Dienste
+macos-menu-application-menu = { -app-name }
+macos-menu-quit-app = { -app-name } beenden
+
+# common 'File' menu items
+common-menu-file-menu = Datei
+common-menu-file-new = Neu
+common-menu-file-new-window = Neues Fenster
+
+common-menu-file-open = Öffnen...
+common-menu-file-close = Schließen
+
+common-menu-file-save = Speichern
+# used for new files, if we need to show a dialog
+common-menu-file-save-ellipsis = Speichern...
+common-menu-file-save-as = Speichern als...
+
+common-menu-file-page-setup = Seiteneinstellungen...
+common-menu-file-print = Drucken...
+
+# windows 'File' menu items
+win-menu-file-exit = Beenden
+
+# common 'Edit' menu items.
+common-menu-edit-menu = Bearbeiten
+
+common-menu-cut = Ausschneiden
+common-menu-copy = Kopieren
+common-menu-paste = Einfügen
+common-menu-undo = Rückgängig
+common-menu-redo = Wiederherstellen
+menu-item-delete = Löschen
+
+menu-item-select-all = Alles auswählen
+menu-item-deselect-all = Auswahl zurücksetzen
+
+# common 'Víew' menu items.
+menu-view-menu = Ansicht
+
+menu-item-increase-zoom = Heranzoomen
+menu-item-decrease-zoom = Herauszoomen
+menu-item-reset-zoom = Zoom zurücksetzen
+
+# common 'Glyph' menu items.
+
+menu-glyph-menu = Zeichen
+menu-item-new-glyph = Neues Zeichen
+menu-item-delete-glyph = Zeichen entfernen
+menu-item-add-component = Komponente hinzufügen
+
+# common 'Tools' menu items.
+menu-tools-menu = Tools
+
+menu-item-select-tool = Auswahl
+menu-item-pen-tool = Stift
+menu-item-preview-tool = Vorschau
+menu-item-rectangle-tool = Rechteck
+
+# font info
+button-edit = (bearbeiten)
+button-done = Fertig
+font-info-cap-height = Versalhöhe:
+font-info-x-height = x-Höhe:
+font-info-ascender = Oberlänge:
+font-info-descender = Unterlänge:

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,10 @@ fn make_ui() -> impl Widget<AppState> {
         format!("{} {}", data.info.family_name, data.info.style_name)
     });
 
-    let button = Button::new("(edit)").on_click(|ctx, _data, _env| {
+    let button = Button::new(
+            LocalizedString::new("button-edit")
+            .with_placeholder("(edit)")
+        ).on_click(|ctx, _data, _env| {
         let cmd = ModalHost::make_modal_command(crate::widgets::font_info);
         ctx.submit_command(cmd, None);
     });

--- a/src/widgets/fontinfo.rs
+++ b/src/widgets/fontinfo.rs
@@ -4,7 +4,7 @@
 
 use druid::widget::prelude::*;
 use druid::widget::{Button, CrossAxisAlignment, Flex, Label};
-use druid::{Color, LensExt, WidgetExt};
+use druid::{Color, LensExt, LocalizedString, WidgetExt};
 
 use norad::GlyphName;
 
@@ -29,7 +29,7 @@ pub fn font_info() -> impl Widget<Workspace> {
         .with_spacer(8.0)
         .with_child(
             Flex::row()
-                .with_child(Label::new("Cap height:"))
+                .with_child(Label::new(LocalizedString::new("font-info-cap-height").with_placeholder("Cap height:")))
                 .with_spacer(8.0)
                 .with_child(
                     option_f64_editlabel()
@@ -38,7 +38,7 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("x-height:"))
+                .with_child(Label::new(LocalizedString::new("font-info-x-height").with_placeholder("x-height:")))
                 .with_spacer(8.0)
                 .with_child(
                     option_f64_editlabel()
@@ -47,7 +47,7 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("ascender:"))
+                .with_child(Label::new(LocalizedString::new("font-info-ascender").with_placeholder("ascender:")))
                 .with_spacer(8.0)
                 .with_child(
                     option_f64_editlabel()
@@ -56,7 +56,7 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("descender:").center())
+                .with_child(Label::new(LocalizedString::new("font-info-descender").with_placeholder("descender:")).center())
                 .with_spacer(8.0)
                 .with_child(
                     option_f64_editlabel()
@@ -65,7 +65,7 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_flex_spacer(1.0)
         .with_child(
-            Button::new("Done")
+            Button::new(LocalizedString::new("button-done").with_placeholder("Done"))
                 .on_click(|ctx, _, _| ctx.submit_command(ModalHost::DISMISS_MODAL, None)),
         )
         .cross_axis_alignment(CrossAxisAlignment::End)


### PR DESCRIPTION
Although there is no locale switching functionality implemented yet, I was able to test this by using druid 0.6 locally via `[patch.crates-io]` and making `get_locale()` return `"de-DE"` instead of `"en-US"`.