### PR TITLE
Improvements to pen and select

### DIFF
--- a/src/design_space.rs
+++ b/src/design_space.rs
@@ -86,6 +86,10 @@ impl DPoint {
     pub(super) fn to_raw(self) -> Point {
         Point::new(self.x, self.y)
     }
+
+    pub fn lerp(self, other: DPoint, t: f64) -> DPoint {
+        DPoint::from_raw(self.to_raw().lerp(other.to_raw(), t))
+    }
 }
 
 impl DVec2 {

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -52,7 +52,7 @@ use druid::kurbo::Point;
 use druid::{Modifiers, MouseButton, MouseButtons, MouseEvent};
 use std::mem;
 
-const DEFAULT_MIN_DRAG_DISTANCE: f64 = 10.0;
+const DEFAULT_MIN_DRAG_DISTANCE: f64 = 2.0;
 
 /// Handles raw mouse events, parsing them into gestures that it forwards
 /// to a delegate.

--- a/src/tools/knife.rs
+++ b/src/tools/knife.rs
@@ -519,7 +519,7 @@ mod tests {
         let mut path = Path::new(DPoint::new(10., 10.));
         path.append_point(DPoint::new(0., 0.));
         path.append_point(DPoint::new(20., 0.));
-        path.append_point(DPoint::new(10., 10.0));
+        path.close();
 
         let line = Line::new((3., 6.), (8., -2.));
         let mut out = Vec::new();


### PR DESCRIPTION
Quite a few new functions and improvements in pen and select tools.

Pen:
* Clicking on a segment splits the segment there.
* Clicking on a point only closes an open path.
* Points are only appended to open paths.
* Keyboard command for deleting the selection.
* Default "trailing" is lerped, not coincident with start.

Select:
* Clicking on a segment selects it.
* Alt-clicking a line segment upgrades it to a cubic.

Both tools:
* Hit testing is based on priorities.

And some general code improvements.