### PR TITLE
Shift-constrained selection dragging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=93620d1#93620d1bb5f39583b82bdf0c5fd4ff676cd03807"
+source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
 dependencies = [
  "console_log",
  "druid-derive",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.3.1"
-source = "git+https://github.com/linebender/druid.git?rev=93620d1#93620d1bb5f39583b82bdf0c5fd4ff676cd03807"
+source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=93620d1#93620d1bb5f39583b82bdf0c5fd4ff676cd03807"
+source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ svg = "0.8.0"
 chrono = "0.4"
 
 [patch.crates-io]
-druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev ="93620d1" }
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "76baabd" }
 

--- a/src/design_space.rs
+++ b/src/design_space.rs
@@ -93,6 +93,8 @@ impl DPoint {
 }
 
 impl DVec2 {
+    pub const ZERO: DVec2 = DVec2 { x: 0.0, y: 0.0 };
+
     fn new(x: f64, y: f64) -> DVec2 {
         assert!(x.is_finite() && y.is_finite() && x.fract() == 0. && y.fract() == 0.);
         DVec2 { x, y }
@@ -113,6 +115,15 @@ impl DVec2 {
     #[inline]
     pub fn hypot(self) -> f64 {
         self.to_raw().hypot()
+    }
+
+    /// The vector snapped to the closest axis.
+    pub fn axis_locked(self) -> DVec2 {
+        if self.x.abs() > self.y.abs() {
+            DVec2::new(self.x, 0.0)
+        } else {
+            DVec2::new(0.0, self.y)
+        }
     }
 }
 

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -466,6 +466,14 @@ impl EditSession {
         }
     }
 
+    pub(crate) fn update_handle(&mut self, point: Point, is_locked: bool) {
+        let dpoint = self.viewport.from_screen(point);
+        let id = *self.selection.iter().next().unwrap();
+        if let Some(path) = self.path_for_point_mut(id) {
+            path.update_handle(id, dpoint, is_locked);
+        }
+    }
+
     pub(crate) fn add_guide(&mut self, point: Point) {
         // if one or two points are selected, use them. else use argument point.
         let guide = match self.selection.len() {


### PR DESCRIPTION
When shift-dragging in selection mode, apply axis locking logic. When
dragging a handle (off-curve point), require it to be axis aligned to
its corresponding on-curve point. Otherwise axis lock the delta from the
original position.

There's a rough edge:

* Pressing and releasing shift should recompute (right now it waits for
  another drag event).

Note: this also snaps to latest Druid because I'm working from the tip.