### PR TITLE
Align selection command

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -47,6 +47,9 @@ pub mod cmd {
     /// sent by the 'add component' menu item
     pub const ADD_COMPONENT: Selector = Selector::new("runebender.add-component");
 
+    /// sent by 'align selection' menu item in Paths menu
+    pub const ALIGN_SELECTION: Selector = Selector::new("runebender.align-selection");
+
     /// Sent when a new tool has been selected.
     ///
     /// The payload must be a `ToolId`.

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -474,6 +474,26 @@ impl EditSession {
         }
     }
 
+    pub(crate) fn align_selection(&mut self) {
+        let bbox = self.selection_dpoint_bbox();
+        // TODO: is_empty() would be cleaner but hasn't landed yet
+        if bbox.area() == 0.0 {
+            return;
+        }
+        let (val, set_x) = if bbox.width() < bbox.height() {
+            (0.5 * (bbox.x0 + bbox.x1), true)
+        } else {
+            (0.5 * (bbox.y0 + bbox.y1), false)
+        };
+        // make borrow checker happy; we could state-split the paths instead, but meh
+        let ids: Vec<EntityId> = self.selection.iter().copied().collect();
+        for id in ids {
+            if let Some(path) = self.path_for_point_mut(id) {
+                path.align_point(id, val, set_x);
+            }
+        }
+    }
+
     pub(crate) fn add_guide(&mut self, point: Point) {
         // if one or two points are selected, use them. else use argument point.
         let guide = match self.selection.len() {

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -44,6 +44,7 @@ pub(crate) fn make_menu(data: &AppState) -> MenuDesc<AppState> {
         .append(edit_menu())
         .append(view_menu())
         .append(glyph_menu(data))
+        .append(paths_menu())
         .append(tools_menu())
 }
 
@@ -110,7 +111,7 @@ fn edit_menu<T: Data>() -> MenuDesc<T> {
                 LocalizedString::new("menu-item-deselect-all").with_placeholder("Deselect All"),
                 consts::cmd::DESELECT_ALL,
             )
-            .hotkey(SysMods::CmdShift, "A"),
+            .hotkey(SysMods::AltCmd, "A"),
         )
 }
 
@@ -164,6 +165,16 @@ fn glyph_menu(data: &AppState) -> MenuDesc<AppState> {
             .hotkey(SysMods::CmdShift, "C")
             .disabled(),
         )
+}
+
+fn paths_menu<T: Data>() -> MenuDesc<T> {
+    MenuDesc::new(LocalizedString::new("menu-paths-menu").with_placeholder("Paths")).append(
+        MenuItem::new(
+            LocalizedString::new("menu-item-align-selection").with_placeholder("Align Selection"),
+            consts::cmd::ALIGN_SELECTION,
+        )
+        .hotkey(SysMods::CmdShift, "A"),
+    )
 }
 
 fn tools_menu<T: Data>() -> MenuDesc<T> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -696,6 +696,17 @@ impl Path {
         self.trailing = Some(handle);
     }
 
+    pub(crate) fn align_point(&mut self, point: EntityId, val: f64, set_x: bool) {
+        if let Some(idx) = self.idx_for_point(point) {
+            let points = self.points_mut();
+            if set_x {
+                points[idx].point.x = val;
+            } else {
+                points[idx].point.y = val;
+            }
+        }
+    }
+
     // in an open path, the first point is essentially a `move_to` command.
     // 'closing' the path means moving this point to the end of the list.
     pub fn close(&mut self) -> EntityId {

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -189,6 +189,7 @@ impl Editor {
             }
             c if c.is(consts::cmd::ALIGN_SELECTION) => {
                 data.session_mut().align_selection();
+                return (true, Some(EditType::Normal));
             }
             // all unhandled commands:
             _ => return (false, None),

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -187,6 +187,9 @@ impl Editor {
                     data.session_mut().viewport = saved_viewport;
                 }
             }
+            c if c.is(consts::cmd::ALIGN_SELECTION) => {
+                data.session_mut().align_selection();
+            }
             // all unhandled commands:
             _ => return (false, None),
         }


### PR DESCRIPTION
When multiple points are selected, squash the minor axis towards the
midpoint of the bbox.

A rough edge: the command doesn't register for undo.