### PR TITLE
Fix EditableLabel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
+source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
 dependencies = [
  "console_log",
  "druid-derive",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.3.1"
-source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
+source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=76baabd#76baabdf3c99041f2154ef3d739fc9f31770718a"
+source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ svg = "0.8.0"
 chrono = "0.4"
 
 [patch.crates-io]
-druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "76baabd" }
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "24c55d1" }
 


### PR DESCRIPTION
The previous implementation did not survive the changes to the
druid TextBox widget.

This implementation is also a bit hacky, but overall I like it
better; instead of holding onto both a label and a textbox, we
just use a textbox but synthesize its data while editing.

When we draw it as a 'label', we just grab the inner layout
object and draw it directly.