### PR TITLE
Text improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
+source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
 dependencies = [
  "console_log",
  "druid-derive",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.3.1"
-source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
+source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=24c55d1#24c55d18e22f1e2719b58a0797e8366937a12ae4"
+source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ svg = "0.8.0"
 chrono = "0.4"
 
 [patch.crates-io]
-druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "24c55d1" }
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "63e34fa2" }
 

--- a/src/widgets/coord_pane.rs
+++ b/src/widgets/coord_pane.rs
@@ -2,10 +2,11 @@
 //! selected point.
 
 use druid::kurbo::{Circle, Vec2};
-use druid::widget::{prelude::*, Controller, Either, Flex, Label, SizedBox};
-use druid::{Color, Point, WidgetExt};
+use druid::widget::{prelude::*, Controller, CrossAxisAlignment, Either, Flex, Label, SizedBox};
+use druid::{Color, FontDescriptor, FontFamily, FontStyle, Point, WidgetExt};
 
 use crate::edit_session::{CoordinateSelection, Quadrant};
+use crate::theme;
 use crate::widgets::EditableLabel;
 
 /// A panel for editing the selected coordinate
@@ -101,18 +102,39 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
         SizedBox::empty(),
     );
 
+    let coord_label_font: FontDescriptor =
+        FontDescriptor::new(FontFamily::SERIF).with_style(FontStyle::Italic);
+
     let coord_editor = Flex::column()
         .with_child(
             Flex::row()
-                .with_child(Label::new("x:").with_text_size(12.0))
-                .with_spacer(4.0)
-                .with_child(EditableLabel::parse().lens(point_x_lens).fix_width(40.0)),
+                .cross_axis_alignment(CrossAxisAlignment::Baseline)
+                .with_child(
+                    Label::new("x")
+                        .with_font(coord_label_font.clone())
+                        .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                )
+                .with_child(
+                    EditableLabel::parse()
+                        .with_font(theme::UI_DETAIL_FONT)
+                        .lens(point_x_lens)
+                        .fix_width(40.0),
+                ),
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("y:").with_text_size(12.0))
-                .with_spacer(4.0)
-                .with_child(EditableLabel::parse().lens(point_y_lens).fix_width(40.0)),
+                .cross_axis_alignment(CrossAxisAlignment::Baseline)
+                .with_child(
+                    Label::new("y")
+                        .with_font(coord_label_font)
+                        .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                )
+                .with_child(
+                    EditableLabel::parse()
+                        .with_font(theme::UI_DETAIL_FONT)
+                        .lens(point_y_lens)
+                        .fix_width(40.0),
+                ),
         )
         .lens(CoordinateSelection::quadrant_coord);
 

--- a/src/widgets/editable_label.rs
+++ b/src/widgets/editable_label.rs
@@ -19,7 +19,7 @@
 use druid::text::EditAction;
 use druid::widget::prelude::*;
 use druid::widget::{LabelText, TextBox};
-use druid::{Data, HotKey, Insets, KbKey, Selector};
+use druid::{Color, Data, FontDescriptor, HotKey, Insets, KbKey, KeyOrValue, Selector};
 
 // we send this to ourselves if another widget takes focus, in order
 // to validate and move out of editing mode
@@ -79,8 +79,34 @@ impl<T: Data> EditableLabel<T> {
         }
     }
 
+    /// Builder-style method to set the placeholder text.
     pub fn with_placeholder(mut self, text: impl Into<String>) -> Self {
         self.text_box = self.text_box.with_placeholder(text);
+        self
+    }
+
+    /// Builder-style method for setting the font.
+    ///
+    /// The argument can be a [`FontDescriptor`] or a [`Key<FontDescriptor>`]
+    /// that refers to a font defined in the [`Env`].
+    ///
+    /// [`Env`]: ../struct.Env.html
+    /// [`FontDescriptor`]: ../struct.FontDescriptor.html
+    /// [`Key<FontDescriptor>`]: ../struct.Key.html
+    pub fn with_font(mut self, font: impl Into<KeyOrValue<FontDescriptor>>) -> Self {
+        self.text_box.set_font(font);
+        self
+    }
+
+    /// Builder-style method to override the text size.
+    pub fn with_text_size(mut self, size: f64) -> Self {
+        self.text_box.set_text_size(size);
+        self
+    }
+
+    /// Builder-style method to set  the text color.
+    pub fn with_text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
+        self.text_box.set_text_color(color);
         self
     }
 

--- a/src/widgets/fontinfo.rs
+++ b/src/widgets/fontinfo.rs
@@ -9,6 +9,7 @@ use druid::{Color, LensExt, WidgetExt};
 use norad::GlyphName;
 
 use crate::data::{FontMetrics, SimpleFontInfo, Workspace};
+use crate::theme;
 use crate::widgets::{EditableLabel, ModalHost};
 
 fn glyphname_label() -> EditableLabel<GlyphName> {
@@ -23,14 +24,14 @@ pub fn font_info() -> impl Widget<Workspace> {
         .with_child(
             Flex::row()
                 .with_child(glyphname_label().lens(SimpleFontInfo::family_name))
-                .with_spacer(8.0)
+                .with_default_spacer()
                 .with_child(glyphname_label().lens(SimpleFontInfo::style_name)),
         )
-        .with_spacer(8.0)
+        .with_default_spacer()
         .with_child(
             Flex::row()
-                .with_child(Label::new("Cap height:"))
-                .with_spacer(8.0)
+                .with_child(Label::new("Cap height:").with_text_color(theme::SECONDARY_TEXT_COLOR))
+                .with_default_spacer()
                 .with_child(
                     option_f64_editlabel()
                         .lens(SimpleFontInfo::metrics.then(FontMetrics::cap_height)),
@@ -38,8 +39,8 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("x-height:"))
-                .with_spacer(8.0)
+                .with_child(Label::new("x-height:").with_text_color(theme::SECONDARY_TEXT_COLOR))
+                .with_default_spacer()
                 .with_child(
                     option_f64_editlabel()
                         .lens(SimpleFontInfo::metrics.then(FontMetrics::x_height)),
@@ -47,8 +48,8 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("ascender:"))
-                .with_spacer(8.0)
+                .with_child(Label::new("Ascender:").with_text_color(theme::SECONDARY_TEXT_COLOR))
+                .with_default_spacer()
                 .with_child(
                     option_f64_editlabel()
                         .lens(SimpleFontInfo::metrics.then(FontMetrics::ascender)),
@@ -56,8 +57,12 @@ pub fn font_info() -> impl Widget<Workspace> {
         )
         .with_child(
             Flex::row()
-                .with_child(Label::new("descender:").center())
-                .with_spacer(8.0)
+                .with_child(
+                    Label::new("Descender:")
+                        .with_text_color(theme::SECONDARY_TEXT_COLOR)
+                        .center(),
+                )
+                .with_default_spacer()
                 .with_child(
                     option_f64_editlabel()
                         .lens(SimpleFontInfo::metrics.then(FontMetrics::descender)),


### PR DESCRIPTION
This is mostly just baseline aligning labels with their text fields and a few font tweaks.

The baseline alignment stuff won't work when an `EditableLabel` is in 'label mode' until https://github.com/linebender/druid/pull/1319 lands.