### PR TITLE
Update druid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
+source = "git+https://github.com/linebender/druid.git?rev=7f1fa18#7f1fa183c9291bc8fea4dc02412777c423b6111b"
 dependencies = [
  "console_log",
  "druid-derive",
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.3.1"
-source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
+source = "git+https://github.com/linebender/druid.git?rev=7f1fa18#7f1fa183c9291bc8fea4dc02412777c423b6111b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=63e34fa2#63e34fa24ebdea07fb869afd69667899c2ce3bbe"
+source = "git+https://github.com/linebender/druid.git?rev=7f1fa18#7f1fa183c9291bc8fea4dc02412777c423b6111b"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ svg = "0.8.0"
 chrono = "0.4"
 
 [patch.crates-io]
-druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "63e34fa2" }
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "7f1fa18" }
 


### PR DESCRIPTION
The main change here is continued improvements to the scroll widget,
by @jneem; in particular we no longer need to pass the size around
in order to set the scroll position, which was a major papercut.

Thanks Joe!