### PR TITLE
Make coord panel partipate in undo

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,10 +8,11 @@ pub const GLYPHS_APP_PASTEBOARD_TYPE: FormatId = "Glyphs elements pasteboard typ
 
 /// Commands and Selectors
 pub mod cmd {
-    use druid::kurbo::Point;
+    use druid::kurbo::{Point, Vec2};
     use druid::Selector;
     use norad::GlyphName;
 
+    use crate::design_space::{DPoint, DVec2};
     use crate::path::EntityId;
     use crate::tools::ToolId;
 
@@ -94,4 +95,16 @@ pub mod cmd {
     /// This is sent by the `EditorController` when focus is changing to 'no widget',
     /// as might happen after we finish editing a coordinate via a text field.
     pub const TAKE_FOCUS: Selector = Selector::new("runebender.editor-steal-focus");
+
+    /// Sent from the coord panel when a coordinate is manually edited.
+    pub const NUDGE_SELECTION: Selector<DVec2> = Selector::new("runebender.editor-nudge-selection");
+
+    /// Sent from the coord panel when the selection bbox is manually edited.
+    pub const SCALE_SELECTION: Selector<ScaleSelectionArgs> =
+        Selector::new("runebender.editor-scale-selection");
+
+    pub struct ScaleSelectionArgs {
+        pub scale: Vec2,
+        pub origin: DPoint,
+    }
 }

--- a/src/edit_session.rs
+++ b/src/edit_session.rs
@@ -472,7 +472,7 @@ impl EditSession {
         }
     }
 
-    fn scale_selection(&mut self, scale: Vec2, anchor: DPoint) {
+    pub(crate) fn scale_selection(&mut self, scale: Vec2, anchor: DPoint) {
         if !self.selection.is_empty() {
             let sel = PathSelection::new(&self.selection);
             for path_points in sel.iter() {
@@ -675,7 +675,7 @@ impl Quadrant {
         }
     }
 
-    pub fn pos_in_size(self, size: Size) -> Point {
+    pub(crate) fn pos_in_size(self, size: Size) -> Point {
         match self {
             Quadrant::TopLeft => Point::new(0., 0.),
             Quadrant::Top => Point::new(size.width / 2.0, 0.),
@@ -689,7 +689,7 @@ impl Quadrant {
         }
     }
 
-    fn pos_in_rect_in_design_space(self, rect: Rect) -> Point {
+    pub(crate) fn pos_in_rect_in_design_space(self, rect: Rect) -> Point {
         let flipped = match self {
             Quadrant::TopRight => Quadrant::BottomRight,
             Quadrant::TopLeft => Quadrant::BottomLeft,
@@ -735,21 +735,6 @@ pub mod lenses {
                 frame,
             };
             let r = f(&mut sel);
-            // if the user has modified the origin, translate the selection
-            if sel.frame.origin() != frame.origin() {
-                let delta = sel.frame.origin() - frame.origin();
-                data.nudge_selection(DVec2::from_raw(delta));
-            }
-
-            // if the user has modified the size, scale the selection
-            if sel.frame.size() != frame.size() {
-                let scale_x = sel.frame.width() / frame.width();
-                let scale_y = sel.frame.height() / frame.height();
-                let scale = Vec2::new(scale_x, scale_y);
-
-                let scale_origin = sel.quadrant.pos_in_rect_in_design_space(frame);
-                data.scale_selection(scale, DPoint::from_raw(scale_origin));
-            }
             data.quadrant = sel.quadrant;
             r
         }
@@ -784,7 +769,6 @@ pub mod lenses {
 
     impl Lens<CoordinateSelection, Size> for QuadrantBbox {
         fn with<V, F: FnOnce(&Size) -> V>(&self, data: &CoordinateSelection, f: F) -> V {
-            //let point = data.quadrant.pos_in_rect_in_design_space(data.frame);
             f(&data.frame.size())
         }
 

--- a/src/widgets/controller.rs
+++ b/src/widgets/controller.rs
@@ -1,9 +1,7 @@
 //! Controller widgets
 
 use druid::widget::{prelude::*, Controller};
-use druid::{
-    Env, Event, EventCtx, InternalLifeCycle, LensExt, Rect, UpdateCtx, Widget, WidgetExt, WidgetPod,
-};
+use druid::{InternalLifeCycle, LensExt, Rect, WidgetExt, WidgetPod};
 
 use crate::consts;
 use crate::data::{AppState, EditorState};

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -186,6 +186,17 @@ impl Editor {
                 data.session_mut().align_selection();
                 return (true, Some(EditType::Normal));
             }
+            c if c.is(consts::cmd::NUDGE_SELECTION) => {
+                let nudge = c.get_unchecked(consts::cmd::NUDGE_SELECTION);
+                data.session_mut().nudge_selection(*nudge);
+                return (true, Some(EditType::Normal));
+            }
+            c if c.is(consts::cmd::SCALE_SELECTION) => {
+                let consts::cmd::ScaleSelectionArgs { scale, origin } =
+                    c.get_unchecked(consts::cmd::SCALE_SELECTION);
+                data.session_mut().scale_selection(*scale, *origin);
+                return (true, Some(EditType::Normal));
+            }
             // all unhandled commands:
             _ => return (false, None),
         }


### PR DESCRIPTION
Instead of modifying the data directly, the coord panel now just
sends a command to the editor asking *it* to modify the data.