### PR TITLE
Cleanup lenses

### DIFF
--- a/src/app_delegate.rs
+++ b/src/app_delegate.rs
@@ -12,7 +12,7 @@ use druid::widget::WidgetExt;
 use norad::{GlyphName, Ufo};
 
 use crate::consts;
-use crate::data::{lenses, AppState};
+use crate::data::{AppState, Workspace};
 use crate::edit_session::EditSession;
 use crate::widgets::{Editor, EditorController, RootWindowController, ScrollZoom};
 
@@ -116,6 +116,6 @@ impl AppDelegate<AppState> for Delegate {
 
 fn make_editor(session: &Arc<EditSession>) -> impl Widget<AppState> {
     EditorController::new(ScrollZoom::new(Editor::new(session.clone())))
-        .lens(AppState::workspace.then(lenses::app_state::EditorState(session.id)))
+        .lens(AppState::workspace.then(Workspace::editor_state(session.id)))
         .controller(RootWindowController::default())
 }

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -10,7 +10,7 @@ use druid::widget::prelude::*;
 use druid::{Data, Insets, TextLayout, WidgetExt, WidgetPod};
 
 use crate::app_delegate::EDIT_GLYPH;
-use crate::data::{lenses, GridGlyph, Workspace};
+use crate::data::{GridGlyph, Workspace};
 use crate::theme;
 use crate::widgets::Maybe;
 
@@ -27,7 +27,7 @@ impl GlyphGrid {
         for key in data.font.ufo.iter_names() {
             let widget = Maybe::or_empty(GridInner::new);
             self.children.push(WidgetPod::new(
-                widget.lens(lenses::app_state::GridGlyph(key)).boxed(),
+                widget.lens(Workspace::glyph_grid(key)).boxed(),
             ));
         }
     }

--- a/src/widgets/sidebar.rs
+++ b/src/widgets/sidebar.rs
@@ -10,7 +10,7 @@ use druid::widget::{Controller, Flex, Label, SizedBox, WidgetExt};
 
 use norad::GlyphName;
 
-use crate::data::{lenses, SelectedGlyph, Workspace};
+use crate::data::{SelectedGlyph, Workspace};
 use crate::theme;
 use crate::widgets::{EditableLabel, Maybe};
 
@@ -33,7 +33,7 @@ fn selected_glyph_widget() -> impl Widget<SelectedGlyph> {
                 },
             )
             .controller(RenameController)
-            .lens(lenses::app_state::GlyphName),
+            .lens(SelectedGlyph::glyph_name),
         )
         .with_child(
             Maybe::new(
@@ -48,13 +48,13 @@ fn selected_glyph_widget() -> impl Widget<SelectedGlyph> {
                         .with_font(theme::UI_DETAIL_FONT)
                 },
             )
-            .lens(lenses::app_state::Codepoint),
+            .lens(SelectedGlyph::codepoint),
         )
         .with_flex_child(GlyphPainter::new(), 1.0)
         .with_child(
             EditableLabel::parse()
                 .fix_width(45.)
-                .lens(lenses::app_state::Advance),
+                .lens(SelectedGlyph::advance),
         )
         .with_child(
             Flex::row()
@@ -81,7 +81,7 @@ impl Sidebar {
                     || selected_glyph_widget().boxed(),
                     || SizedBox::empty().expand_width().boxed(),
                 )
-                .lens(lenses::app_state::SelectedGlyph)
+                .lens(Workspace::selected_glyph)
                 .fix_height(SELECTED_GLYPH_HEIGHT)
                 .background(Color::grey8(0xCC))
                 .boxed(),


### PR DESCRIPTION
This standardizes on the behaviour of exposing lenses as either
associated constants or type methods, and removes an unnecessary
level of nesting in data::lenses submodule.