### PR TITLE
Add EditableLable::text_alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "druid"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=31d4bdf9#31d4bdf9c5c97250804157ddbe88d758055b057a"
+source = "git+https://github.com/linebender/druid.git?rev=9e839421#9e83942178634e4d519c1de1062f231cce8cae12"
 dependencies = [
  "console_log",
  "druid-derive",
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 name = "druid-derive"
 version = "0.3.1"
-source = "git+https://github.com/linebender/druid.git?rev=31d4bdf9#31d4bdf9c5c97250804157ddbe88d758055b057a"
+source = "git+https://github.com/linebender/druid.git?rev=9e839421#9e83942178634e4d519c1de1062f231cce8cae12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "druid-shell"
 version = "0.6.0"
-source = "git+https://github.com/linebender/druid.git?rev=31d4bdf9#31d4bdf9c5c97250804157ddbe88d758055b057a"
+source = "git+https://github.com/linebender/druid.git?rev=9e839421#9e83942178634e4d519c1de1062f231cce8cae12"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,4 @@ svg = "0.8.0"
 chrono = "0.4"
 
 [patch.crates-io]
-druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "31d4bdf9" }
-
+druid = { version = "0.6.0", git = "https://github.com/linebender/druid.git", rev = "9e839421" }

--- a/src/widgets/editable_label.rs
+++ b/src/widgets/editable_label.rs
@@ -19,16 +19,13 @@
 use druid::text::EditAction;
 use druid::widget::prelude::*;
 use druid::widget::{LabelText, TextBox};
-use druid::{Color, Data, FontDescriptor, HotKey, Insets, KbKey, KeyOrValue, Selector};
+use druid::{Color, Data, FontDescriptor, HotKey, KbKey, KeyOrValue, Selector, TextAlignment};
 
 // we send this to ourselves if another widget takes focus, in order
 // to validate and move out of editing mode
 //const LOST_FOCUS: Selector = Selector::new("druid.builtin.EditableLabel-lost-focus");
 const CANCEL_EDITING: Selector = Selector::new("druid.builtin.EditableLabel-cancel-editing");
 const COMPLETE_EDITING: Selector = Selector::new("druid.builtin.EditableLabel-complete-editing");
-
-/// These are just taken from the druid TextBox widget
-const TEXT_INSETS: Insets = Insets::new(4.0, 2.0, 0.0, 2.0);
 
 /// A label with text that can be edited.
 ///
@@ -107,6 +104,12 @@ impl<T: Data> EditableLabel<T> {
     /// Builder-style method to set  the text color.
     pub fn with_text_color(mut self, color: impl Into<KeyOrValue<Color>>) -> Self {
         self.text_box.set_text_color(color);
+        self
+    }
+
+    /// Builder-style method to set the [`TextAlignment`].
+    pub fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
+        self.text_box.set_text_alignment(alignment);
         self
     }
 
@@ -227,7 +230,7 @@ impl<T: Data> Widget<T> for EditableLabel<T> {
         if self.editing {
             self.text_box.paint(ctx, &self.buffer, env);
         } else {
-            let text_pos = (TEXT_INSETS.x0, TEXT_INSETS.y0);
+            let text_pos = self.text_box.text_position();
             self.text_box.editor().layout().draw(ctx, text_pos);
         }
     }

--- a/src/widgets/glyph_pane.rs
+++ b/src/widgets/glyph_pane.rs
@@ -63,6 +63,7 @@ fn build_widget() -> impl Widget<EditorState> {
                 .with_child(
                     EditableLabel::parse()
                         .with_font(theme::UI_DETAIL_FONT)
+                        .with_text_alignment(druid::TextAlignment::End)
                         .lens(Sidebearings::left)
                         .controller(GlyphPane)
                         .lens(EditorState::sidebearings)
@@ -79,6 +80,7 @@ fn build_widget() -> impl Widget<EditorState> {
                 .with_child(
                     EditableLabel::parse()
                         .with_font(theme::UI_DETAIL_FONT)
+                        .with_text_alignment(druid::TextAlignment::Start)
                         .lens(Sidebearings::right)
                         .controller(GlyphPane)
                         .lens(EditorState::sidebearings)
@@ -88,6 +90,7 @@ fn build_widget() -> impl Widget<EditorState> {
         .with_child(
             EditableLabel::parse()
                 .with_font(theme::UI_DETAIL_FONT)
+                .with_text_alignment(druid::TextAlignment::Center)
                 .lens(EditorState::detail_glyph.then(GlyphDetail::advance))
                 .fix_width(40.0),
         )


### PR DESCRIPTION


This allows these labels to be draw their contents centered
or aligned to either edge, as desired.

before:
![Screen Shot 2020-12-03 at 10 45 51 AM](https://user-images.githubusercontent.com/3330916/101052523-b8453380-3554-11eb-8fa4-72bd7be6182a.png)
after:
![Screen Shot 2020-12-03 at 10 45 05 AM](https://user-images.githubusercontent.com/3330916/101052448-9cda2880-3554-11eb-9211-117cd025b04d.png)
