### PR TITLE
Update tools menu to reflect the current toolbar

### DIFF
--- a/src/menus.rs
+++ b/src/menus.rs
@@ -214,4 +214,25 @@ fn tools_menu<T: Data>() -> MenuDesc<T> {
             )
             .hotkey(SysMods::None, "u"),
         )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-ellipse-tool").with_placeholder("Ellipse"),
+                consts::cmd::SET_TOOL.with("Ellipse"),
+            )
+            .hotkey(SysMods::Shift, "u"),
+        )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-knife-tool").with_placeholder("Knife"),
+                consts::cmd::SET_TOOL.with("Knife"),
+            )
+            .hotkey(SysMods::None, "e"),
+        )
+        .append(
+            MenuItem::new(
+                LocalizedString::new("menu-item-measure-tool").with_placeholder("Measure"),
+                consts::cmd::SET_TOOL.with("Measure"),
+            )
+            .hotkey(SysMods::None, "m"),
+        )
 }


### PR DESCRIPTION
Adds Ellipse, Knife, and Measure options, which currently exist in the toolbar, but not the tool menu. In PR #136 there is some discussion about the need for this update.

I tested this on both macOS 11 and elementaryOS(GTK).

![update-tools-menu](https://user-images.githubusercontent.com/5162664/101722820-e00a2f00-3a5f-11eb-91ba-20feef4e7420.png)
