### PR TITLE
Add x-height and cap-height guides to the editor's metrics box

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -73,7 +73,8 @@ impl<'a, 'b: 'a> DrawCtx<'a, 'b> {
 
     fn draw_metrics(&mut self, glyph: &Glyph, metrics: &FontMetrics) {
         let upm = metrics.units_per_em;
-        //let cap_height = metrics.cap_height.unwrap_or((upm * 0.7).round());
+        let x_height = metrics.x_height.unwrap_or_else(|| (upm * 0.5).round());
+        let cap_height = metrics.cap_height.unwrap_or_else(|| (upm * 0.7).round());
         let ascender = metrics.ascender.unwrap_or_else(|| (upm * 0.8).round());
         let descender = metrics.descender.unwrap_or_else(|| -(upm * 0.2).round());
         let hadvance = glyph
@@ -81,13 +82,22 @@ impl<'a, 'b: 'a> DrawCtx<'a, 'b> {
             .as_ref()
             .map(|a| a.width as f64)
             .unwrap_or_else(|| (upm * 0.5).round());
+
         let bounds = Rect::from_points((0., descender), (hadvance, ascender));
         let bounds = self.space.rect_to_screen(bounds);
-
         self.stroke(bounds, &METRICS_COLOR, 1.0);
+
         let baseline = Line::new((0.0, 0.0), (hadvance, 0.0));
         let baseline = self.space.affine() * baseline;
         self.stroke(baseline, &METRICS_COLOR, 1.0);
+
+        let x_height_guide = Line::new((0.0, x_height), (hadvance, x_height));
+        let x_height_guide = self.space.affine() * x_height_guide;
+        self.stroke(x_height_guide, &METRICS_COLOR, 1.0);
+
+        let cap_height_guide = Line::new((0.0, cap_height), (hadvance, cap_height));
+        let cap_height_guide = self.space.affine() * cap_height_guide;
+        self.stroke(cap_height_guide, &METRICS_COLOR, 1.0);
     }
 
     fn draw_grid(&mut self) {


### PR DESCRIPTION
I tested this on macOS 11 and Debian Linux, it loads non-standard x/cap-heights from UFO sources. Before this update there wasn't an easy way to see where the x and cap heights were in the metrics box.

<img width="512" alt="x-cap-height-guides" src="https://user-images.githubusercontent.com/5162664/102370791-559b6100-3f72-11eb-9857-02ccce1926cb.png">
