### PR TITLE
Update glyph grid UI design

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -40,9 +40,9 @@ pub mod colors {
 pub fn configure_env(env: &mut Env) {
     env.set(SIDEBAR_BACKGROUND, colors::LIGHT_GREY);
     env.set(SIDEBAR_EDGE_STROKE, colors::SIDEBAR_EDGE);
-    env.set(PLACEHOLDER_GLYPH_COLOR, colors::LIGHT_GREY);
+    env.set(PLACEHOLDER_GLYPH_COLOR, Color::grey8(0xBB));
     env.set(GLYPH_LIST_STROKE, colors::LIGHT_GREY);
-    env.set(GLYPH_LIST_BACKGROUND, Color::WHITE);
+    env.set(GLYPH_LIST_BACKGROUND, Color::grey8(0xF0));
     env.set(PRIMARY_TEXT_COLOR, Color::BLACK);
     env.set(SECONDARY_TEXT_COLOR, colors::MEDIUM_GREY);
     env.set(SELECTION_RECT_STROKE_COLOR, colors::LIGHT_BLUE);

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -3,13 +3,14 @@
 use std::sync::Arc;
 
 use druid::widget::prelude::*;
-use druid::{Application, Clipboard, ClipboardFormat, Color, Command, ContextMenu, Data, KbKey};
+use druid::{Application, Clipboard, ClipboardFormat, Command, ContextMenu, Data, KbKey};
 
 use crate::consts::{self, CANVAS_SIZE};
 use crate::data::EditorState;
 use crate::draw;
 use crate::edit_session::EditSession;
 use crate::mouse::{Mouse, TaggedEvent};
+use crate::theme;
 use crate::tools::{EditType, Select, Tool};
 use crate::undo::UndoState;
 
@@ -234,7 +235,7 @@ impl Editor {
 impl Widget<EditorState> for Editor {
     fn paint(&mut self, ctx: &mut PaintCtx, data: &EditorState, env: &Env) {
         let rect = (CANVAS_SIZE * data.session.viewport.zoom).to_rect();
-        ctx.fill(rect, &Color::WHITE);
+        ctx.fill(rect, &env.get(theme::GLYPH_LIST_BACKGROUND));
 
         draw::draw_session(
             ctx,


### PR DESCRIPTION
Adds a new glyph box style and off-white background color
Removes the full-width baseline graphic
Spacing adjustments

See the macOS 11 screenshot below:
<img width="935" alt="update-glyph-grid-ui-design" src="https://user-images.githubusercontent.com/5162664/102751307-55a5b300-431c-11eb-8f42-2546ea3be2b3.png">
