### PR TITLE
Move Entity, PathPoint, PointType to point.rs

### DIFF
--- a/runebender-lib/src/component.rs
+++ b/runebender-lib/src/component.rs
@@ -5,7 +5,7 @@ use druid::Data;
 use norad::GlyphName;
 
 use crate::design_space::DVec2;
-use crate::path::EntityId;
+use crate::point::EntityId;
 
 #[derive(Debug, Data, Clone)]
 pub struct Component {
@@ -23,7 +23,7 @@ impl Component {
     pub fn from_norad(src: &norad::glyph::Component) -> Self {
         let base = src.base.clone();
         let transform = src.transform.into();
-        let id = EntityId::new_with_parent(0);
+        let id = EntityId::next();
         Component {
             base,
             transform,

--- a/runebender-lib/src/consts.rs
+++ b/runebender-lib/src/consts.rs
@@ -13,7 +13,7 @@ pub mod cmd {
     use norad::GlyphName;
 
     use crate::design_space::{DPoint, DVec2};
-    use crate::path::EntityId;
+    use crate::point::EntityId;
     use crate::tools::ToolId;
 
     /// Sent when windows should rebuild their menus.

--- a/runebender-lib/src/draw.rs
+++ b/runebender-lib/src/draw.rs
@@ -7,7 +7,8 @@ use crate::data::{FontMetrics, Workspace};
 use crate::design_space::ViewPort;
 use crate::edit_session::EditSession;
 use crate::guides::{Guide, GuideLine};
-use crate::path::{Path, PathSeg, PointType};
+use crate::path::{Path, PathSeg};
+use crate::point::PointType;
 use crate::selection::Selection;
 use crate::theme;
 
@@ -363,9 +364,9 @@ impl<'a> PointIter<'a> {
         }
 
         match this.typ {
-            PointType::OnCurve => Style::Corner,
-            PointType::OffCurve => Style::OffCurve,
-            PointType::OnCurveSmooth => {
+            PointType::OffCurve { .. } => Style::OffCurve,
+            PointType::OnCurve { smooth: false } => Style::Corner,
+            PointType::OnCurve { smooth: true } => {
                 let prev = self.path.prev_point(this.id);
                 let next = self.path.next_point(this.id);
                 match (prev.is_on_curve(), next.is_on_curve()) {

--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -10,7 +10,8 @@ use crate::component::Component;
 use crate::data::Workspace;
 use crate::design_space::{DPoint, DVec2, ViewPort};
 use crate::guides::Guide;
-use crate::path::{EntityId, Path, PathPoint, PathSeg};
+use crate::path::{Path, PathSeg};
+use crate::point::{EntityId, PathPoint};
 use crate::quadrant::Quadrant;
 use crate::selection::Selection;
 

--- a/runebender-lib/src/guides.rs
+++ b/runebender-lib/src/guides.rs
@@ -2,7 +2,7 @@ use druid::kurbo::{Line, ParamCurveNearest, Point, Vec2};
 use druid::Data;
 
 use crate::design_space::{DPoint, DVec2, ViewPort};
-use crate::path::EntityId;
+use crate::point::EntityId;
 
 #[derive(Debug, Clone, Data)]
 pub struct Guide {
@@ -100,7 +100,7 @@ impl Guide {
             }
         };
 
-        let id = EntityId::new_with_parent(0);
+        let id = EntityId::new_for_guide();
         Guide { guide, id }
     }
 

--- a/runebender-lib/src/lib.rs
+++ b/runebender-lib/src/lib.rs
@@ -20,6 +20,7 @@ mod glyph_names;
 mod guides;
 mod path;
 mod plist;
+mod point;
 mod quadrant;
 mod selection;
 mod tools;

--- a/runebender-lib/src/point.rs
+++ b/runebender-lib/src/point.rs
@@ -1,0 +1,194 @@
+//! Points and sequences of points, used to represent paths.
+//!
+//! This is intended to be agnostic to whether the path is a bezier or a
+//! hyperbezier.
+
+use super::design_space::{DPoint, ViewPort};
+
+use druid::kurbo::Point;
+use druid::Data;
+use norad::glyph::PointType as NoradPointType;
+
+const RESERVED_ID_COUNT: IdComponent = 5;
+const NO_PARENT_TYPE_ID: IdComponent = 0;
+const GUIDE_TYPE_ID: IdComponent = 1;
+
+type IdComponent = usize;
+
+#[derive(Debug, Clone, Copy, Data, PartialEq, PartialOrd, Hash, Eq, Ord)]
+/// A unique identifier for some entity, such as a point or a component.
+///
+/// The entity has two parts; the first ('parent') identifies the type of the
+/// entity or the identity of its containing path (for points) and the second
+/// ('child') identifies the item itself.
+///
+/// A given id will be unique across the application at any given time.
+pub struct EntityId {
+    parent: IdComponent,
+    point: IdComponent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Data)]
+pub enum PointType {
+    OnCurve { smooth: bool },
+    OffCurve { auto: bool },
+}
+
+#[derive(Clone, Copy, Data, PartialEq)]
+pub struct PathPoint {
+    pub id: EntityId,
+    pub point: DPoint,
+    pub typ: PointType,
+}
+
+impl EntityId {
+    /// Returns a new unique id.
+    ///
+    /// This id will have no associated parent. If you want a parent idea,
+    /// use [`EntityId::new_with_parent`].
+    pub fn next() -> EntityId {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(RESERVED_ID_COUNT);
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        EntityId {
+            parent: NO_PARENT_TYPE_ID,
+            point: id,
+        }
+    }
+
+    pub fn new_with_parent(parent: EntityId) -> Self {
+        EntityId {
+            parent: parent.point,
+            ..EntityId::next()
+        }
+    }
+
+    #[inline]
+    pub fn new_for_guide() -> Self {
+        EntityId {
+            parent: GUIDE_TYPE_ID,
+            ..EntityId::next()
+        }
+    }
+
+    /// Return the `EntityId` representing this id's parent.
+    ///
+    /// If this entity's parent has its own parent, it will not be present.
+    pub fn parent(self) -> EntityId {
+        EntityId {
+            parent: NO_PARENT_TYPE_ID,
+            point: self.parent,
+        }
+    }
+
+    pub fn is_guide(self) -> bool {
+        self.parent == GUIDE_TYPE_ID
+    }
+
+    pub(crate) fn parent_eq(self, other: EntityId) -> bool {
+        self.parent == other.parent
+    }
+
+    pub(crate) fn is_child_of(self, other: EntityId) -> bool {
+        self.parent == other.point
+    }
+}
+
+impl PointType {
+    pub fn is_on_curve(self) -> bool {
+        matches!(self, PointType::OnCurve { .. })
+    }
+
+    pub fn is_off_curve(self) -> bool {
+        matches!(self, PointType::OffCurve { .. })
+    }
+
+    pub fn is_smooth(&self) -> bool {
+        matches!(self, PointType::OnCurve { smooth: true })
+    }
+
+    /// Toggle smooth to corner and auto to non-auto
+    pub fn toggle_type(&mut self) {
+        match self {
+            PointType::OnCurve { smooth } => *smooth = !*smooth,
+            PointType::OffCurve { auto } => *auto = !*auto,
+        }
+    }
+
+    pub fn from_norad(norad_type: &NoradPointType, smooth: bool) -> Self {
+        match norad_type {
+            NoradPointType::OffCurve => PointType::OffCurve { auto: false },
+            NoradPointType::QCurve => panic!(
+                "quadratics unsupported, we should have \
+                         validated input before now"
+            ),
+            NoradPointType::Move | NoradPointType::Line | NoradPointType::Curve if smooth => {
+                PointType::OnCurve { smooth: true }
+            }
+            _other => PointType::OnCurve { smooth: false },
+        }
+    }
+}
+
+impl PathPoint {
+    pub fn off_curve(path: EntityId, point: DPoint) -> PathPoint {
+        let id = EntityId::new_with_parent(path);
+        PathPoint {
+            id,
+            point,
+            typ: PointType::OffCurve { auto: false },
+        }
+    }
+
+    pub fn on_curve(path: EntityId, point: DPoint) -> PathPoint {
+        let id = EntityId::new_with_parent(path);
+        PathPoint {
+            id,
+            point,
+            typ: PointType::OnCurve { smooth: false },
+        }
+    }
+
+    pub fn is_on_curve(&self) -> bool {
+        self.typ.is_on_curve()
+    }
+
+    pub fn is_off_curve(&self) -> bool {
+        self.typ.is_off_curve()
+    }
+
+    pub fn is_smooth(&self) -> bool {
+        self.typ.is_smooth()
+    }
+
+    pub fn toggle_type(&mut self) {
+        self.typ.toggle_type();
+    }
+
+    pub fn reparent(&mut self, new_parent: EntityId) {
+        self.id.parent = new_parent.point;
+    }
+
+    /// The distance, in screen space, from this `PathPoint` to `point`, a point
+    /// in screen space.
+    pub fn screen_dist(&self, vport: ViewPort, point: Point) -> f64 {
+        self.point.to_screen(vport).distance(point)
+    }
+
+    /// Convert this point to point in screen space.
+    pub fn to_screen(&self, vport: ViewPort) -> Point {
+        self.point.to_screen(vport)
+    }
+}
+
+impl std::fmt::Debug for PathPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}: {:.2} {:?}", self.id, self.point, self.typ)
+    }
+}
+
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "id{}.{}", self.parent, self.point)
+    }
+}

--- a/runebender-lib/src/selection.rs
+++ b/runebender-lib/src/selection.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use druid::Data;
 
-use crate::path::EntityId;
+use crate::point::EntityId;
 
 /// A sorted set of selected items.
 #[derive(Debug, Clone, Data)]

--- a/runebender-lib/src/tools/knife.rs
+++ b/runebender-lib/src/tools/knife.rs
@@ -7,7 +7,8 @@ use druid::{Color, Env, EventCtx, KbKey, KeyEvent, MouseEvent, PaintCtx, Point, 
 use crate::design_space::DPoint;
 use crate::edit_session::EditSession;
 use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
-use crate::path::{Path, PathPoint, PathSeg};
+use crate::path::{Path, PathSeg};
+use crate::point::{EntityId, PathPoint};
 use crate::tools::{EditType, Tool};
 
 const MAX_RECURSE: usize = 16;
@@ -360,7 +361,7 @@ fn slice_path_impl(
 /// The 'second' path is the part that is 'sliced off', and it always closed.
 fn split_path_at_intersections(path: &Path, start: Hit, end: Hit) -> (Path, Path) {
     let one_id = path.id();
-    let two_id = crate::path::next_id();
+    let two_id = EntityId::next();
     let mut one_points = Vec::new();
     let mut two_points = Vec::new();
     let mut iter = path.iter_segments();
@@ -419,9 +420,9 @@ fn split_path_at_intersections(path: &Path, start: Hit, end: Hit) -> (Path, Path
 }
 
 /// set tangent handles, set correct parent ids, and construct the path
-fn finalize_path(mut points: Vec<PathPoint>, parent_id: usize, closed: bool) -> Path {
+fn finalize_path(mut points: Vec<PathPoint>, parent_id: EntityId, closed: bool) -> Path {
     crate::path::mark_tangent_handles(&mut points);
-    points.iter_mut().for_each(|p| p.id.set_parent(parent_id));
+    points.iter_mut().for_each(|p| p.reparent(parent_id));
     if closed {
         points.rotate_left(1);
     }

--- a/runebender-lib/src/tools/rectangle.rs
+++ b/runebender-lib/src/tools/rectangle.rs
@@ -8,7 +8,8 @@ use druid::{
 use crate::design_space::DPoint;
 use crate::edit_session::EditSession;
 use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
-use crate::path::{Path, PathPoint};
+use crate::path::Path;
+use crate::point::{EntityId, PathPoint};
 use crate::tools::{EditType, Tool};
 
 /// The state of the rectangle tool.
@@ -188,7 +189,7 @@ impl Default for GestureState {
 }
 
 fn make_rect_path(p1: DPoint, p3: DPoint) -> Path {
-    let path_id = crate::path::next_id();
+    let path_id = EntityId::next();
     let p2 = DPoint::new(p3.x, p1.y);
     let p4 = DPoint::new(p1.x, p3.y);
     // first point goes last in closed paths


### PR DESCRIPTION
This is preliminary work towards spline integration; I would like
to start breaking up path.rs in order to share as much code as
is reasonable between the bezier and hyperbezier splines.

In particular I want to use the same type to represent the actual
vec of offcurve and on-curve points; there's a bunch of fiddly logic
here, and I think it can be reasonably well isolated and reused.

This doesn't do that (although it *does* change the representation
of PointType, in anticipation of having auto points) but it lays
the groundwork.