### PR TITLE
Move hardcoded glyph grid cell colors to theme

### DIFF
--- a/resources/dark.theme
+++ b/resources/dark.theme
@@ -1,0 +1,52 @@
+// A dark theme file
+// these are comments; blank lines are ignored
+
+SIDEBAR_BACKGROUND:                 #222
+SIDEBAR_EDGE_STROKE:                #333
+PLACEHOLDER_GLYPH_COLOR:            #aaa
+GLYPH_LIST_STROKE:                  #fff
+GLYPH_LIST_BACKGROUND:              #111
+GLYPH_GRID_CELL_BACKGROUND_COLOR:   #222
+GLYPH_GRID_CELL_OUTLINE_COLOR:      #555
+FOCUS_BACKGROUND_COLOR:             #114400
+FOCUS_OUTLINE_COLOR:                #aaff55
+PRIMARY_TEXT_COLOR:                 #fff
+SECONDARY_TEXT_COLOR:               #222
+SELECTION_RECT_STROKE_COLOR:        #0f2
+SELECTION_RECT_FILL_COLOR:          #0f25
+
+SELECTION_COLOR:                #a6ccff
+LABEL_COLOR:                    #05f
+WINDOW_BACKGROUND_COLOR:        #fff
+BACKGROUND_LIGHT:               #eee
+CURSOR_COLOR:                   #000
+BUTTON_DARK:                    #c8c8c8
+BUTTON_LIGHT:                   #fff
+
+// drawing of paths and points in the editor
+
+PATH_STROKE_COLOR:              #fff
+PATH_FILL_COLOR:                #fff    // during preview
+METRICS_COLOR:                  #555    // the color of the ascender/descender/em box
+
+GUIDE_COLOR:                    #fc5493
+SELECTED_GUIDE_COLOR:           #ffee55
+SELECTED_LINE_SEGMENT_COLOR:    #ffee55
+SELECTED_POINT_INNER_COLOR:     #ffaa11
+SELECTED_POINT_OUTER_COLOR:     #ffee55
+SMOOTH_POINT_OUTER_COLOR:       #579aff
+SMOOTH_POINT_INNER_COLOR:       #4428ec
+CORNER_POINT_OUTER_COLOR:       #6ae756
+CORNER_POINT_INNER_COLOR:       #208e56
+OFF_CURVE_POINT_OUTER_COLOR:    #ff99ff
+OFF_CURVE_POINT_INNER_COLOR:    #ff00ff
+OFF_CURVE_HANDLE_COLOR:         #bbb
+DIRECTION_ARROW_COLOR:          #6ae75699
+COMPONENT_FILL_COLOR:           #f004
+
+SMOOTH_RADIUS:                  6.
+SMOOTH_SELECTED_RADIUS:         7.5
+CORNER_RADIUS:                  5.5
+CORNER_SELECTED_RADIUS:         7.
+OFF_CURVE_RADIUS:               4.5
+OFF_CURVE_SELECTED_RADIUS:      6.

--- a/resources/default.theme
+++ b/resources/default.theme
@@ -1,16 +1,19 @@
 // A sample theme file
 // these are comments; blank lines are ignored
 
-SIDEBAR_BACKGROUND:             #e7e7e7
-SIDEBAR_EDGE_STROKE:            #c7c7c7
-PLACEHOLDER_GLYPH_COLOR:        #bbb
-GLYPH_LIST_STROKE:              #e7e7e7
-GLYPH_LIST_BACKGROUND:          #f0f0f0
-PRIMARY_TEXT_COLOR:             #000
-SECONDARY_TEXT_COLOR:           #888
-SELECTION_RECT_STROKE_COLOR:    #538bbb
-SELECTION_RECT_FILL_COLOR:      #ddd5
-
+SIDEBAR_BACKGROUND:                 #e7e7e7
+SIDEBAR_EDGE_STROKE:                #c7c7c7
+PLACEHOLDER_GLYPH_COLOR:            #bbb
+GLYPH_LIST_STROKE:                  #e7e7e7
+GLYPH_LIST_BACKGROUND:              #f0f0f0
+GLYPH_GRID_CELL_BACKGROUND_COLOR:   #ddd
+GLYPH_GRID_CELL_OUTLINE_COLOR:      #aaa
+FOCUS_BACKGROUND_COLOR:             #ffee55
+FOCUS_OUTLINE_COLOR:                #ffaa11
+PRIMARY_TEXT_COLOR:                 #000
+SECONDARY_TEXT_COLOR:               #888
+SELECTION_RECT_STROKE_COLOR:        #538bbb
+SELECTION_RECT_FILL_COLOR:          #ddd5
 
 SELECTION_COLOR:                #a6ccff
 LABEL_COLOR:                    #000

--- a/runebender-lib/src/theme.rs
+++ b/runebender-lib/src/theme.rs
@@ -14,6 +14,14 @@ pub const SIDEBAR_EDGE_STROKE: Key<Color> = Key::new("runebender.sidebar-edge-st
 pub const GLYPH_LIST_BACKGROUND: Key<Color> = Key::new("runebender.background");
 pub const GLYPH_LIST_STROKE: Key<Color> = Key::new("runebender.glyph-list-stroke");
 
+/// Colors for the root window glyph grids cells.
+pub const GLYPH_GRID_CELL_BACKGROUND_COLOR: Key<Color> =
+    Key::new("runebender.glyph-grid-cell-background-color");
+pub const GLYPH_GRID_CELL_OUTLINE_COLOR: Key<Color> =
+    Key::new("runebender.glyph-grid-cell-outline-color");
+pub const FOCUS_BACKGROUND_COLOR: Key<Color> = Key::new("runebender.focus-background-color");
+pub const FOCUS_OUTLINE_COLOR: Key<Color> = Key::new("runebender.focus-outline-color");
+
 /// The color for placeholder glyphs
 pub const PLACEHOLDER_GLYPH_COLOR: Key<Color> = Key::new("runebender.placeholder-glyph-color");
 /// The color for primary text, filled glyph outlines, etc
@@ -72,6 +80,10 @@ druid_theme_loader::loadable_theme!(pub MyTheme {
     PLACEHOLDER_GLYPH_COLOR,
     GLYPH_LIST_STROKE,
     GLYPH_LIST_BACKGROUND,
+    GLYPH_GRID_CELL_BACKGROUND_COLOR,
+    GLYPH_GRID_CELL_OUTLINE_COLOR,
+    FOCUS_BACKGROUND_COLOR,
+    FOCUS_OUTLINE_COLOR,
     PRIMARY_TEXT_COLOR,
     SECONDARY_TEXT_COLOR,
     SELECTION_RECT_STROKE_COLOR,

--- a/runebender-lib/src/widgets/grid.rs
+++ b/runebender-lib/src/widgets/grid.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use druid::kurbo::{Affine, Rect, Shape, Size};
-use druid::piet::Color;
 //use druid::piet::{
 //FontBuilder, PietText, PietTextLayout, RenderContext, Text, TextLayout, TextLayoutBuilder,
 //};
@@ -155,13 +154,11 @@ impl Widget<GridGlyph> for GridInner {
 
         let glyph_rect: Rect = geom - Insets::uniform(5.0);
         let rounded = glyph_rect.to_rounded_rect(5.0);
-        ctx.fill(rounded, &Color::grey8(0xD0));
-        ctx.stroke(rounded, &Color::grey8(0xA0), 2.0);
-
-        let hl_color = Color::rgb8(0xFF, 0xEE, 0x55);
+        ctx.fill(rounded, &env.get(theme::GLYPH_GRID_CELL_BACKGROUND_COLOR));
+        ctx.stroke(rounded, &env.get(theme::GLYPH_GRID_CELL_OUTLINE_COLOR), 2.0);
         if ctx.is_active() || data.is_selected {
-            ctx.fill(rounded, &hl_color);
-            ctx.stroke(rounded, &Color::rgb8(0xFF, 0xAA, 0x11), 4.0);
+            ctx.fill(rounded, &env.get(theme::FOCUS_BACKGROUND_COLOR));
+            ctx.stroke(rounded, &env.get(theme::FOCUS_OUTLINE_COLOR), 4.0);
         }
         let glyph_color = if data.is_placeholder {
             env.get(theme::PLACEHOLDER_GLYPH_COLOR)


### PR DESCRIPTION
- This moves all hardcoded colors from `widgets/grid.rs` to the theme system
- Adds a basic dark theme

Mac OS 11.1 screenshot, note that the glyph grid cells can't be styled to fit the dark theme with hardcoded color values:
<img width="1510" alt="pr-205--001" src="https://user-images.githubusercontent.com/5162664/104977284-0357c080-59b4-11eb-96df-e429537ee519.png">