### PR TITLE
Move knife tool colors to the theme system

### DIFF
--- a/resources/dark.theme
+++ b/resources/dark.theme
@@ -23,6 +23,10 @@ CURSOR_COLOR:                   #000
 BUTTON_DARK:                    #c8c8c8
 BUTTON_LIGHT:                   #fff
 
+// tools
+KNIFE_GUIDE:                    #0f2
+KNIFE_GUIDE_INTERSECTION:       #f00
+
 // drawing of paths and points in the editor
 
 PATH_STROKE_COLOR:              #fff

--- a/resources/default.theme
+++ b/resources/default.theme
@@ -23,6 +23,10 @@ CURSOR_COLOR:                   #000
 BUTTON_DARK:                    #c8c8c8
 BUTTON_LIGHT:                   #fff
 
+// tools
+KNIFE_GUIDE:                    #888
+KNIFE_GUIDE_INTERSECTION:       #f00
+
 // drawing of paths and points in the editor
 
 PATH_STROKE_COLOR:              #000

--- a/runebender-lib/src/theme.rs
+++ b/runebender-lib/src/theme.rs
@@ -62,6 +62,10 @@ pub const OFF_CURVE_HANDLE_COLOR: Key<Color> = Key::new("runebender.off-curve-ha
 pub const DIRECTION_ARROW_COLOR: Key<Color> = Key::new("runebender.direction-arrow-color");
 pub const COMPONENT_FILL_COLOR: Key<Color> = Key::new("runebender.component-fill-color");
 
+// Colors used by tools in the tool menu
+pub const KNIFE_GUIDE: Key<Color> = Key::new("runebender.knife-guide");
+pub const KNIFE_GUIDE_INTERSECTION: Key<Color> = Key::new("runebender.knife-guide-intersection");
+
 pub const SMOOTH_RADIUS: Key<f64> = Key::new("runebender.smooth-point-radius");
 pub const SMOOTH_SELECTED_RADIUS: Key<f64> = Key::new("runebender.smooth-point-selected-radius");
 pub const CORNER_RADIUS: Key<f64> = Key::new("runebender.corner-point-radius");
@@ -112,6 +116,8 @@ druid_theme_loader::loadable_theme!(pub MyTheme {
     OFF_CURVE_HANDLE_COLOR,
     DIRECTION_ARROW_COLOR,
     COMPONENT_FILL_COLOR,
+    KNIFE_GUIDE,
+    KNIFE_GUIDE_INTERSECTION,
     SMOOTH_RADIUS,
     SMOOTH_SELECTED_RADIUS,
     CORNER_RADIUS,

--- a/runebender-lib/src/tools/knife.rs
+++ b/runebender-lib/src/tools/knife.rs
@@ -2,13 +2,14 @@
 
 use druid::kurbo::{Line, LineIntersection, ParamCurve, ParamCurveArclen};
 use druid::piet::StrokeStyle;
-use druid::{Color, Env, EventCtx, KbKey, KeyEvent, MouseEvent, PaintCtx, Point, RenderContext};
+use druid::{Env, EventCtx, KbKey, KeyEvent, MouseEvent, PaintCtx, Point, RenderContext};
 
 use crate::design_space::DPoint;
 use crate::edit_session::EditSession;
 use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
 use crate::path::{Path, PathSeg};
 use crate::point::{EntityId, PathPoint};
+use crate::theme;
 use crate::tools::{EditType, Tool};
 
 const MAX_RECURSE: usize = 16;
@@ -176,14 +177,14 @@ impl Tool for Knife {
             let unit_vec = (line.end() - line.start()).normalize();
             //let perp = druid::kurbo::Vec2::new(-unit_vec.y, unit_vec.x);
 
-            ctx.stroke_styled(line, &Color::BLACK, 1.0, &self.stroke_style);
+            ctx.stroke_styled(line, &_env.get(theme::KNIFE_GUIDE), 2.0, &self.stroke_style);
 
             for point in &self.intersections {
                 let point = data.viewport.to_screen(*point);
                 let cut_mark_start = point - (unit_vec * 4.0);
                 let cut_mark_end = point + (unit_vec * 4.0);
                 let cut_mark = Line::new(cut_mark_start, cut_mark_end);
-                ctx.stroke(cut_mark, &Color::rgb(0.7, 0., 0.), 2.0);
+                ctx.stroke(cut_mark, &_env.get(theme::KNIFE_GUIDE_INTERSECTION), 8.0);
 
                 //let cms1 = cut_mark_start + perp * 2.0;
                 //let cme1 = cut_mark_end + perp * 2.0;


### PR DESCRIPTION
Adds knife guide and intersection colors to the theme system.

MacOS 11.0.1 Screenshots of `default.theme` and `dark.theme`:
<img width="330" alt="default-theme-knife-update" src="https://user-images.githubusercontent.com/5162664/105625478-8925a280-5dde-11eb-9de1-4db4e59a4f31.png">
<img width="390" alt="dark-theme-knife-update" src="https://user-images.githubusercontent.com/5162664/105625480-8dea5680-5dde-11eb-8653-5a50b2219cc7.png">

