### PR TITLE
Pen improvements

### DIFF
--- a/runebender-lib/src/cubic_path.rs
+++ b/runebender-lib/src/cubic_path.rs
@@ -203,29 +203,6 @@ impl CubicPath {
         let post_seg = seg.subsegment(t..1.0);
         self.points.split_segment(seg, pre_seg, post_seg);
     }
-
-    pub(crate) fn convert_last_to_curve(&mut self, handle: DPoint) {
-        if self.points.len() > 1 {
-            let mut prev = self.points.points_mut().pop().unwrap();
-            assert!(prev.is_on_curve() && !prev.is_smooth());
-            prev.toggle_type();
-            let p1 = self.path_points().trailing().unwrap_or_else(|| {
-                self.path_points()
-                    .trailing_point_in_open_path()
-                    .unwrap()
-                    .point
-                    .lerp(prev.point, 1.0 / 3.0)
-            });
-            let p2 = prev.point - (handle - prev.point);
-            let pts = &[
-                PathPoint::off_curve(self.points.id(), p1),
-                PathPoint::off_curve(self.points.id(), p2),
-                prev,
-            ];
-            self.path_points_mut().points_mut().extend(pts);
-        }
-        self.path_points_mut().set_trailing(handle);
-    }
 }
 
 impl From<PathPoints> for CubicPath {

--- a/runebender-lib/src/draw.rs
+++ b/runebender-lib/src/draw.rs
@@ -451,7 +451,7 @@ pub(crate) fn draw_session(
 
         if let Some(pt) = path.trailing() {
             if path.should_draw_trailing() {
-                draw_ctx.draw_off_curve_point(pt.to_screen(space), true, env);
+                draw_ctx.draw_auto_point(pt.to_screen(space), false, env);
             }
         }
     }

--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -319,11 +319,6 @@ impl EditSession {
         self.paths_mut().extend(paths);
     }
 
-    pub fn update_for_drag(&mut self, drag_point: Point) {
-        let drag_point = self.viewport.from_screen(drag_point);
-        self.active_path_mut().unwrap().update_for_drag(drag_point);
-    }
-
     pub fn toggle_point_type(&mut self, id: EntityId) {
         if let Some(path) = self.path_for_point_mut(id) {
             path.toggle_point_type(id)

--- a/runebender-lib/src/hyper_path.rs
+++ b/runebender-lib/src/hyper_path.rs
@@ -227,16 +227,6 @@ impl HyperPath {
         }
     }
 
-    pub(crate) fn convert_last_to_curve(&mut self, _handle: DPoint) {
-        if self.points.len() > 1 {
-            if let Some(prev_point) = self.points.points_mut().pop() {
-                // we should always clear trailing on mouseup?
-                assert!(self.points.trailing().is_none());
-                self.spline_to(prev_point.point, true);
-            }
-        }
-    }
-
     pub(crate) fn split_segment_at_point(&mut self, seg: HyperSegment, t: f64) {
         let pt = DPoint::from_raw(seg.eval(t));
         let path_id = seg.path_seg.start_id().parent();

--- a/runebender-lib/src/point_list.rs
+++ b/runebender-lib/src/point_list.rs
@@ -209,16 +209,12 @@ impl PathPoints {
         self.path_id
     }
 
-    pub fn trailing(&self) -> Option<DPoint> {
+    pub(crate) fn trailing(&self) -> Option<DPoint> {
         self.trailing
     }
 
-    //fn trailing_mut(&mut self) -> Option<&mut DPoint> {
-    //self.trailing.as_mut()
-    //}
-
-    pub fn clear_trailing(&mut self) {
-        self.trailing = None;
+    pub fn take_trailing(&mut self) -> Option<DPoint> {
+        self.trailing.take()
     }
 
     pub fn set_trailing(&mut self, trailing: DPoint) {
@@ -387,15 +383,6 @@ impl PathPoints {
     pub fn start_point(&self) -> &PathPoint {
         assert!(!self.points.is_empty(), "empty path is not constructable");
         self.points.as_ref().get(self.first_idx()).unwrap()
-    }
-
-    /// The trailing on-curve point, if this path is not closed.
-    pub fn trailing_point_in_open_path(&self) -> Option<&PathPoint> {
-        if !self.closed {
-            self.points.as_ref().last()
-        } else {
-            None
-        }
     }
 
     /// Returns the 'last' on-curve point.

--- a/runebender-lib/src/tools/pen.rs
+++ b/runebender-lib/src/tools/pen.rs
@@ -81,13 +81,16 @@ impl MouseDelegate<EditSession> for Pen {
                     dpoint
                 };
                 let is_smooth = event.mods.alt();
-                active.line_to(dpoint, is_smooth);
+                let selection = active.line_to(dpoint, is_smooth);
+                data.selection.select_one(selection);
             } else {
                 let path = if self.hyperbezier_mode {
                     Path::new_hyper(dpoint)
                 } else {
                     Path::new(dpoint)
                 };
+                let selection = path.points().first().unwrap().id;
+                data.selection.select_one(selection);
                 data.add_path(path);
             }
 

--- a/runebender-lib/src/tools/select.rs
+++ b/runebender-lib/src/tools/select.rs
@@ -241,7 +241,7 @@ impl MouseDelegate<EditSession> for Select {
 
                 if event.mods.alt() && seg.is_line() {
                     let path = data.path_for_point_mut(seg.start_id()).unwrap();
-                    path.upgrade_line_seg(seg);
+                    path.upgrade_line_seg(seg, false);
                     self.this_edit_type = Some(EditType::Normal);
                     return;
                 }


### PR DESCRIPTION
This moves to using a state machine internally to track what's happening with the pen.

This also includes two practical changes: it cleans up the logic around the 'trailing point' (the ghost off-curve point you get from a click+drag with the pen tool) and it also correctly sets the selection to the newly added point when a point is added or a path is closed.