### PR TITLE
Implement panning in preview tool

### DIFF
--- a/runebender-lib/src/design_space.rs
+++ b/runebender-lib/src/design_space.rs
@@ -157,6 +157,10 @@ impl DVec2 {
 }
 
 impl ViewPort {
+    pub fn offset(&self) -> Vec2 {
+        self.offset
+    }
+
     pub fn set_offset(&mut self, offset: Vec2) {
         self.offset = offset;
     }

--- a/runebender-lib/src/mouse.rs
+++ b/runebender-lib/src/mouse.rs
@@ -371,8 +371,7 @@ impl Mouse {
         };
     }
 
-    #[allow(dead_code)]
-    fn cancel<T>(&mut self, data: &mut T, delegate: &mut dyn MouseDelegate<T>) {
+    pub fn cancel<T>(&mut self, data: &mut T, delegate: &mut dyn MouseDelegate<T>) {
         let prev_state = mem::replace(&mut self.state, MouseState::Transition);
         let last_event = match prev_state {
             MouseState::Down(event) => event,

--- a/runebender-lib/src/tools/ellipse.rs
+++ b/runebender-lib/src/tools/ellipse.rs
@@ -58,6 +58,16 @@ impl Tool for Ellipse {
         "Ellipse"
     }
 
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        None
+    }
+
     fn key_down(
         &mut self,
         key: &KeyEvent,

--- a/runebender-lib/src/tools/knife.rs
+++ b/runebender-lib/src/tools/knife.rs
@@ -118,6 +118,16 @@ impl Tool for Knife {
         "Knife"
     }
 
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        None
+    }
+
     fn key_down(
         &mut self,
         key: &KeyEvent,

--- a/runebender-lib/src/tools/measure.rs
+++ b/runebender-lib/src/tools/measure.rs
@@ -138,6 +138,16 @@ impl Tool for Measure {
         "Measure"
     }
 
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        None
+    }
+
     fn paint(&mut self, ctx: &mut PaintCtx, data: &EditSession, _env: &Env) {
         self.paint_coords(ctx, data);
         if let Some(line) = self.line {

--- a/runebender-lib/src/tools/mod.rs
+++ b/runebender-lib/src/tools/mod.rs
@@ -19,7 +19,7 @@ pub use select::Select;
 use crate::edit_session::EditSession;
 use crate::mouse::{Mouse, TaggedEvent};
 use druid::kurbo::Point;
-use druid::{Env, EventCtx, KeyEvent, PaintCtx};
+use druid::{Cursor, Env, EventCtx, KeyEvent, PaintCtx};
 
 /// Something to pass around instead of a Box<dyn Tool>
 pub type ToolId = &'static str;
@@ -89,6 +89,24 @@ pub trait Tool {
         None
     }
 
+    /// Called whenever an action is canceled.
+    ///
+    /// The tool should reset the mouse (with [`Mosue::cancel`]) and then
+    /// reset any internal state. When it next receives an event, it should
+    /// behave as if it has been just instantiated.
+    ///
+    /// The tool may optionally return an edit here, if there was some action
+    /// in progress that needs a new undo group.
+    #[allow(unused)]
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        None
+    }
+
     /// Called whenever a tool is first activated, so that it can access or modify
     /// mouse settings.
     #[allow(unused)]
@@ -113,6 +131,10 @@ pub trait Tool {
     }
 
     fn name(&self) -> ToolId;
+
+    fn default_cursor(&self) -> Cursor {
+        Cursor::Arrow
+    }
 }
 
 /// Returns the tool for the given `ToolId`.

--- a/runebender-lib/src/tools/pen.rs
+++ b/runebender-lib/src/tools/pen.rs
@@ -43,8 +43,11 @@ enum State {
 }
 
 impl MouseDelegate<EditSession> for Pen {
-    fn cancel(&mut self, canvas: &mut EditSession) {
-        canvas.selection.clear();
+    fn cancel(&mut self, _canvas: &mut EditSession) {
+        self.this_edit_type = match &self.state {
+            State::DragHandle(..) => Some(EditType::DragUp),
+            _ => None,
+        };
         self.state = State::Ready;
     }
 
@@ -172,6 +175,16 @@ fn current_drag_pos(drag: &Drag, data: &EditSession) -> DPoint {
 }
 
 impl Tool for Pen {
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        self.this_edit_type.take()
+    }
+
     fn mouse_event(
         &mut self,
         event: TaggedEvent,

--- a/runebender-lib/src/tools/preview.rs
+++ b/runebender-lib/src/tools/preview.rs
@@ -4,14 +4,86 @@
 //! the workspace by clicking and dragging, although whether this makes sense
 //! in the era of the touchpad is an open question.
 
-use crate::tools::{Tool, ToolId};
+use druid::widget::prelude::*;
+use druid::{Cursor, MouseEvent};
+
+use crate::edit_session::EditSession;
+use crate::mouse::{Drag, Mouse, MouseDelegate, TaggedEvent};
+use crate::tools::{EditType, Tool, ToolId};
 
 /// The state of the preview tool.
 #[derive(Debug, Default, Clone)]
-pub struct Preview {}
+pub struct Preview {
+    state: State,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum State {
+    Ready,
+    Dragging,
+}
 
 impl Tool for Preview {
     fn name(&self) -> ToolId {
         "Preview"
+    }
+
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        None
+    }
+
+    fn mouse_event(
+        &mut self,
+        event: TaggedEvent,
+        mouse: &mut Mouse,
+        ctx: &mut EventCtx,
+        data: &mut EditSession,
+        _env: &Env,
+    ) -> Option<EditType> {
+        let pre_state = self.state;
+        mouse.mouse_event(event, data, self);
+        if pre_state != self.state {
+            match self.state {
+                State::Ready => ctx.set_cursor(&Cursor::OpenHand),
+                State::Dragging => ctx.set_cursor(&Cursor::OpenHand),
+            }
+        }
+        None
+    }
+
+    fn default_cursor(&self) -> Cursor {
+        Cursor::OpenHand
+    }
+}
+
+impl MouseDelegate<EditSession> for Preview {
+    fn cancel(&mut self, _data: &mut EditSession) {
+        self.state = State::Ready;
+    }
+
+    fn left_down(&mut self, _event: &MouseEvent, _data: &mut EditSession) {
+        self.state = State::Dragging;
+    }
+
+    fn left_up(&mut self, _event: &MouseEvent, _data: &mut EditSession) {
+        self.state = State::Ready;
+    }
+
+    fn left_drag_changed(&mut self, drag: Drag, data: &mut EditSession) {
+        let offset = data.viewport.offset();
+        let delta = drag.current.pos - drag.prev.pos;
+        data.viewport.set_offset(offset + delta);
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Ready
     }
 }

--- a/runebender-lib/src/tools/rectangle.rs
+++ b/runebender-lib/src/tools/rectangle.rs
@@ -73,6 +73,16 @@ impl Tool for Rectangle {
         "Rectangle"
     }
 
+    fn cancel(
+        &mut self,
+        mouse: &mut Mouse,
+        _ctx: &mut EventCtx,
+        data: &mut EditSession,
+    ) -> Option<EditType> {
+        mouse.cancel(data, self);
+        None
+    }
+
     fn key_down(
         &mut self,
         key: &KeyEvent,


### PR DESCRIPTION
The previous implementation was a bit of a hack; this now implements
a real 'preview' tool that supports click and drag to pan.

Making this work also involved actually implementing mouse gesture
canceling, and adds a method to Tool that lets tools specify their
preferred default cursor.


fixes #190