### PR TITLE
Select a new point in path when deleting a single point

### DIFF
--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -336,9 +336,17 @@ impl EditSession {
     pub fn delete_selection(&mut self) {
         let to_delete = self.selection.per_path_selection();
         self.selection.clear();
+        // if only deleting points from a single path, we will select a point
+        // in that path afterwards.
+        let set_sel = to_delete.path_len() == 1;
+
         for path_points in to_delete.iter() {
             if let Some(path) = self.path_for_point_mut(path_points[0]) {
-                path.delete_points(path_points);
+                if let Some(new_sel) = path.delete_points(path_points) {
+                    if set_sel {
+                        self.selection.select_one(new_sel);
+                    }
+                }
             } else if path_points[0].is_guide() {
                 self.guides_mut().retain(|g| !path_points.contains(&g.id));
             }

--- a/runebender-lib/src/path.rs
+++ b/runebender-lib/src/path.rs
@@ -185,9 +185,15 @@ impl Path {
         self.path_points().start_point()
     }
 
-    pub fn delete_points(&mut self, points: &[EntityId]) {
-        self.path_points_mut().delete_points(points);
+    /// Delete a collection of points from this path.
+    ///
+    /// If only a single point was deleted from this path, we will return
+    /// the id of a point in the path that is suitable for setting as the
+    /// new selection.
+    pub fn delete_points(&mut self, points: &[EntityId]) -> Option<EntityId> {
+        let result = self.path_points_mut().delete_points(points);
         self.after_change();
+        result.filter(|_| points.len() == 1)
     }
 
     pub fn close(&mut self, smooth: bool) -> EntityId {

--- a/runebender-lib/src/selection.rs
+++ b/runebender-lib/src/selection.rs
@@ -120,6 +120,17 @@ impl PathSelection {
             idx: 0,
         }
     }
+
+    /// The number of distinct paths represented in the selection.
+    pub fn path_len(&self) -> usize {
+        self.inner
+            .iter()
+            .fold((0, EntityId::next()), |(len, prev), id| {
+                let len = if id.parent_eq(prev) { len } else { len + 1 };
+                (len, *id)
+            })
+            .0
+    }
 }
 
 pub struct PathSelectionIter<'a> {


### PR DESCRIPTION
With this patch, if you delete the last point in an open path
(for instance) the selection will be updated to the new end point.