### PR TITLE
Fix crash on save with missing identifier

### DIFF
--- a/runebender-lib/src/hyper_path.rs
+++ b/runebender-lib/src/hyper_path.rs
@@ -6,7 +6,7 @@ use druid::Data;
 use spline::{Element, Segment as SplineSegment, SplineSpec};
 
 use norad::glyph::{Contour, ContourPoint, PointType};
-use norad::Plist;
+use norad::{Identifier, Plist};
 
 use super::design_space::DPoint;
 use super::point::{EntityId, PathPoint};
@@ -223,8 +223,11 @@ impl HyperPath {
 
         let mut lib = Plist::new();
         lib.insert(HYPERBEZ_LIB_VERSION_KEY.into(), HYPERBEZ_UFO_VERSION.into());
-        let ident = self.path_points().norad_id_for_id(self.path_points().id());
-        Contour::new(points, ident, Some(lib))
+        let ident = self
+            .path_points()
+            .norad_id_for_id(self.path_points().id())
+            .unwrap_or_else(Identifier::from_uuidv4);
+        Contour::new(points, Some(ident), Some(lib))
     }
 
     pub(crate) fn append_to_bezier(&self, bez: &mut BezPath) {


### PR DESCRIPTION
This feels like it might be a norad bug; you should not be able
to construct a Contour that has a lib section but does not have
an identifier, since saving this contour will always panic?

cc @madig, what do you think? This would panic in the
'dumb_object_libs' method of norad...