### PR TITLE
Don't panic on missing glyph in virtual_font

### DIFF
--- a/runebender-lib/src/virtual_font.rs
+++ b/runebender-lib/src/virtual_font.rs
@@ -162,9 +162,7 @@ fn make_horiz_tables(
                 .font
                 .ufo
                 .get_glyph(name)
-                .unwrap()
-                .advance_width()
-                .map(|adv| adv as u16)
+                .and_then(|glyph| glyph.advance_width().map(|adv| adv as u16))
                 .unwrap_or_default();
             HorizontalMetricRecord {
                 advance_width,


### PR DESCRIPTION
This is a particular problem because we always ensure .notdef is
present in the vfont, even if it doesn't exist in the font.

fixes #231