### PR TITLE
Remove the Tools menu bar item for now.

### DIFF
--- a/runebender-lib/src/menus.rs
+++ b/runebender-lib/src/menus.rs
@@ -45,7 +45,6 @@ pub fn make_menu(data: &AppState) -> MenuDesc<AppState> {
         .append(view_menu())
         .append(glyph_menu(data))
         .append(paths_menu())
-        .append(tools_menu())
         .append(window_menu(data))
 }
 
@@ -182,66 +181,6 @@ fn paths_menu<T: Data>() -> MenuDesc<T> {
                 consts::cmd::ALIGN_SELECTION,
             )
             .hotkey(SysMods::CmdShift, "A"),
-        )
-}
-
-fn tools_menu<T: Data>() -> MenuDesc<T> {
-    MenuDesc::new(LocalizedString::new("menu-tools-menu").with_placeholder("Tools"))
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-select-tool").with_placeholder("Select"),
-                consts::cmd::SET_TOOL.with("Select"),
-            )
-            .hotkey(SysMods::None, "v"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-pen-tool").with_placeholder("Pen"),
-                consts::cmd::SET_TOOL.with("Pen"),
-            )
-            .hotkey(SysMods::None, "p"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-hyperpen-tool").with_placeholder("Pen"),
-                consts::cmd::SET_TOOL.with("HyperPen"),
-            )
-            .hotkey(SysMods::Shift, "P"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-preview-tool").with_placeholder("Preview"),
-                consts::cmd::SET_TOOL.with("Preview"),
-            )
-            .hotkey(SysMods::None, "h"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-rectangle-tool").with_placeholder("Rectangle"),
-                consts::cmd::SET_TOOL.with("Rectangle"),
-            )
-            .hotkey(SysMods::None, "u"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-ellipse-tool").with_placeholder("Ellipse"),
-                consts::cmd::SET_TOOL.with("Ellipse"),
-            )
-            .hotkey(SysMods::Shift, "U"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-knife-tool").with_placeholder("Knife"),
-                consts::cmd::SET_TOOL.with("Knife"),
-            )
-            .hotkey(SysMods::None, "e"),
-        )
-        .append(
-            MenuItem::new(
-                LocalizedString::new("menu-item-measure-tool").with_placeholder("Measure"),
-                consts::cmd::SET_TOOL.with("Measure"),
-            )
-            .hotkey(SysMods::None, "m"),
         )
 }
 


### PR DESCRIPTION
Remove the Tools menu bar item for now.                               
                                                                      
On the GTK platform,   there is no straightforward way to disable hot­
keys while editing text,  this means that the menu bar will always re­
ceive these keys before the text input does because AccelGroups always
receive keys before DrawArea. Furthermore,  because  menus are global,
there is nothing available to  menus::make_menu  to disable these menu
items when the focused window is not a glyph editor window,   and this
will be a problem again down the line, when there are non-numeric text
inputs  (e.g. a search box for selecting components to add to a glyph)
in the glyph editor window.                                           
                                                                      
In the future, we can add hax to work around the GTK behavior, or may­
be we'll be onto bigger and better things re the X11 and Wayland plat­
forms by then.                                                        
                                                                      
In the mean time,   the hotkeys still work in the glyph editor window,
where they actually make sense;  maybe tooltips should be used to make
them discoverable, or maybe we just draw hotkeys on/in the tool icons.

This resolves #132 for now.