### PR TITLE
Allow moving only one offcurve without touching its neighbour

### DIFF
--- a/runebender-lib/src/point_list.rs
+++ b/runebender-lib/src/point_list.rs
@@ -458,14 +458,16 @@ impl PathPoints {
         let mut to_xform = HashSet::new();
         for point in points {
             let cursor = self.cursor(Some(*point));
-            if cursor.point().is_some() {
+            if let Some(current) = cursor.point() {
                 to_xform.insert(*point);
-                if let Some(prev) = cursor.peek_prev().filter(|pp| pp.is_off_curve()) {
-                    to_xform.insert(prev.id);
-                }
+                if current.is_on_curve() {
+                    if let Some(prev) = cursor.peek_prev().filter(|pp| pp.is_off_curve()) {
+                        to_xform.insert(prev.id);
+                    }
 
-                if let Some(next) = cursor.peek_next().filter(|pp| pp.is_off_curve()) {
-                    to_xform.insert(next.id);
+                    if let Some(next) = cursor.peek_next().filter(|pp| pp.is_off_curve()) {
+                        to_xform.insert(next.id);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change allows to move only one of two offcurves, while preserving the feature that if you move an on-curve, its off-curves follow.