### PR TITLE
Change the preview fill color from magenta to black

### DIFF
--- a/resources/default.theme
+++ b/resources/default.theme
@@ -30,7 +30,7 @@ KNIFE_GUIDE_INTERSECTION:       #f00
 // drawing of paths and points in the editor
 
 PATH_STROKE_COLOR:              #000
-PATH_FILL_COLOR:                #f1c        // during preview
+PATH_FILL_COLOR:                #000        // during preview
 METRICS_COLOR:                  #a0a0a0     // the color of the ascender/descender/em box
 
 GUIDE_COLOR:                    #fc5493


### PR DESCRIPTION
This is one of the issues from Dave's "various suggestions" issue: https://github.com/linebender/runebender/issues/224

<img width="422" alt="rb-preview-fill-color" src="https://user-images.githubusercontent.com/5162664/116265124-b6f8eb00-a72f-11eb-8381-96709cd98900.png">