### PR TITLE
Update coordinate pane layout padding and spacers

### DIFF
--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -151,7 +151,6 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     Label::new("y")
                         .with_font(coord_label_font.clone())
                         .with_text_color(theme::SECONDARY_TEXT_COLOR),
-                        //.padding((0.0, 0.0, 0.0, 8.0)),
                 )
                 .with_child(
                     EditableLabel::parse()
@@ -171,7 +170,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                         Label::new("w")
                             .with_font(coord_label_font.clone())
                             .with_text_color(theme::SECONDARY_TEXT_COLOR)
-                            .padding((0.0, 0.0, 0.0, 8.0)),
+                            .padding((-0.0, 0.0, 0.0, 8.0)),
                     )
                     .with_spacer(4.0)
                     .with_child(
@@ -187,16 +186,14 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     .with_child(
                         Label::new("h")
                             .with_font(coord_label_font)
-                            .with_text_color(theme::SECONDARY_TEXT_COLOR)
-                            .padding((0.0, 0.0, 0.0, 0.0)),
+                            .with_text_color(theme::SECONDARY_TEXT_COLOR),
                     )
                     .with_spacer(4.0)
                     .with_child(
                         EditableLabel::parse()
                             .with_font(theme::UI_DETAIL_FONT)
                             .lens(size_height_lens)
-                            .fix_width(40.0)
-                            .padding((0.0, 0.0, 0.0, 0.0)),
+                            .fix_width(40.0),
                     ),
             )
             .lens(CoordinateSelection::quadrant_bbox),

--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -187,8 +187,8 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     .with_child(
                         Label::new("h")
                             .with_font(coord_label_font)
-                            .with_text_color(theme::SECONDARY_TEXT_COLOR),
-                            //.padding((0.0, 0.0, 0.0, 8.0)),
+                            .with_text_color(theme::SECONDARY_TEXT_COLOR)
+                            .padding((0.0, 0.0, 0.0, 0.0)),
                     )
                     .with_spacer(4.0)
                     .with_child(
@@ -196,7 +196,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                             .with_font(theme::UI_DETAIL_FONT)
                             .lens(size_height_lens)
                             .fix_width(40.0)
-                            .padding((0.0, 0.0, 0.0, 8.0)),
+                            .padding((0.0, 0.0, 0.0, 0.0)),
                     ),
             )
             .lens(CoordinateSelection::quadrant_bbox),

--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -133,13 +133,15 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                 .with_child(
                     Label::new("x")
                         .with_font(coord_label_font.clone())
-                        .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                        .with_text_color(theme::SECONDARY_TEXT_COLOR)
+                        .padding((0.0, 0.0, 0.0, 8.0)),
                 )
                 .with_child(
                     EditableLabel::parse()
                         .with_font(theme::UI_DETAIL_FONT)
                         .lens(point_x_lens)
-                        .fix_width(40.0),
+                        .fix_width(40.0)
+                        .padding((0.0, 0.0, 0.0, 8.0)),
                 ),
         )
         .with_child(
@@ -149,6 +151,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     Label::new("y")
                         .with_font(coord_label_font.clone())
                         .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                        //.padding((0.0, 0.0, 0.0, 8.0)),
                 )
                 .with_child(
                     EditableLabel::parse()
@@ -167,14 +170,16 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     .with_child(
                         Label::new("w")
                             .with_font(coord_label_font.clone())
-                            .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                            .with_text_color(theme::SECONDARY_TEXT_COLOR)
+                            .padding((0.0, 0.0, 0.0, 8.0)),
                     )
                     .with_spacer(4.0)
                     .with_child(
                         EditableLabel::parse()
                             .with_font(theme::UI_DETAIL_FONT)
                             .lens(size_width_lens)
-                            .fix_width(40.0),
+                            .fix_width(40.0)
+                            .padding((0.0, 0.0, 0.0, 8.0)),
                     ),
             )
             .with_child(
@@ -183,13 +188,15 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                         Label::new("h")
                             .with_font(coord_label_font)
                             .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                            //.padding((0.0, 0.0, 0.0, 8.0)),
                     )
                     .with_spacer(4.0)
                     .with_child(
                         EditableLabel::parse()
                             .with_font(theme::UI_DETAIL_FONT)
                             .lens(size_height_lens)
-                            .fix_width(40.0),
+                            .fix_width(40.0)
+                            .padding((0.0, 0.0, 0.0, 8.0)),
                     ),
             )
             .lens(CoordinateSelection::quadrant_bbox),
@@ -200,7 +207,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
         .with_child(coord_picker)
         .with_child(coord_editor)
         .with_child(bbox_info)
-        .padding(4.0);
+        .padding(8.0);
 
     // if we have any points selected, show the numerical adjust widget, else an empty widget
     Either::new(|d, _| d.count != 0, picker_and_editor, SizedBox::empty())

--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -172,7 +172,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                             .with_text_color(theme::SECONDARY_TEXT_COLOR)
                             .padding((-0.0, 0.0, 0.0, 8.0)),
                     )
-                    .with_spacer(4.0)
+                    .with_spacer(0.0)
                     .with_child(
                         EditableLabel::parse()
                             .with_font(theme::UI_DETAIL_FONT)
@@ -188,7 +188,7 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                             .with_font(coord_label_font)
                             .with_text_color(theme::SECONDARY_TEXT_COLOR),
                     )
-                    .with_spacer(4.0)
+                    .with_spacer(0.0)
                     .with_child(
                         EditableLabel::parse()
                             .with_font(theme::UI_DETAIL_FONT)


### PR DESCRIPTION
Update coordinate pane layout padding and spacers. It still needs some work, but it is an improvement from my perspective.
<img width="108" alt="c-pane-layout-01" src="https://user-images.githubusercontent.com/5162664/124429936-5edbf780-dd23-11eb-87ff-fb435087fbd7.png">
<img width="275" alt="c-pane-layout-02" src="https://user-images.githubusercontent.com/5162664/124429947-61d6e800-dd23-11eb-98f1-399d1e149999.png">
