### PR TITLE
Update glyph-pane layout spacing

### DIFF
--- a/runebender-lib/src/widgets/glyph_pane.rs
+++ b/runebender-lib/src/widgets/glyph_pane.rs
@@ -73,8 +73,8 @@ fn build_widget() -> impl Widget<EditorState> {
                     GlyphPainter::new()
                         .color(theme::SECONDARY_TEXT_COLOR)
                         .draw_layout_frame(true)
-                        .fix_height(40.0)
-                        .padding((0., 8.0))
+                        .fix_height(200.0)
+                        .padding((8.0, 8.0))
                         .lens(EditorState::detail_glyph),
                 )
                 .with_child(
@@ -94,5 +94,5 @@ fn build_widget() -> impl Widget<EditorState> {
                 .lens(EditorState::detail_glyph.then(GlyphDetail::advance))
                 .fix_width(40.0),
         )
-        .padding(4.0)
+        .padding(8.0)
 }


### PR DESCRIPTION
To match the layout spacing of the coordinate pane. See screenshot below:
<img width="1440" alt="Screen Shot 2021-07-05 at 1 04 33 AM" src="https://user-images.githubusercontent.com/5162664/124438902-9d76af80-dd2d-11eb-8fda-ac8513cf7d64.png">
