### PR TITLE
Add rotate start point command

### DIFF
--- a/runebender-lib/src/consts.rs
+++ b/runebender-lib/src/consts.rs
@@ -55,6 +55,9 @@ pub mod cmd {
     // sent by 'reverse contours' menu item in Paths menu
     pub const REVERSE_CONTOURS: Selector = Selector::new("runebender.reverse-contours");
 
+    /// sent by 'rotate start point' menu item in Paths menu
+    pub const ROTATE_START_POINT: Selector = Selector::new("runebender.rotate-start-point");
+
     /// Sent when a new tool has been selected.
     ///
     /// The payload must be a `ToolId`.

--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -511,6 +511,10 @@ impl EditSession {
         }
     }
 
+    pub(crate) fn rotate_start_point(&mut self) {
+        log::info!("Rotate start point")
+    }
+
     pub(crate) fn add_guide(&mut self, point: Point) {
         // if one or two points are selected, use them. else use argument point.
         let guide = match self.selection.len() {

--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -512,7 +512,7 @@ impl EditSession {
     }
 
     pub(crate) fn rotate_start_point(&mut self) {
-        log::info!("Rotate start point")
+        self.paths_mut().rotate_right(1);
     }
 
     pub(crate) fn add_guide(&mut self, point: Point) {

--- a/runebender-lib/src/menus.rs
+++ b/runebender-lib/src/menus.rs
@@ -200,6 +200,14 @@ fn paths_menu<T: Data>() -> Menu<T> {
             .on_activate(|ctx, _, _| ctx.submit_command(consts::cmd::ALIGN_SELECTION))
             .hotkey(SysMods::CmdShift, "A"),
         )
+        .entry(
+            MenuItem::new(
+                LocalizedString::new("menu-item-rotate-start-point")
+                    .with_placeholder("Rotate Start Point"),
+            )
+            .on_activate(|ctx, _, _| ctx.submit_command(consts::cmd::ROTATE_START_POINT))
+            .hotkey(SysMods::CmdShift, "R"),
+        )
 }
 
 fn window_menu(_app_state: &AppState) -> Menu<AppState> {

--- a/runebender-lib/src/widgets/editor.rs
+++ b/runebender-lib/src/widgets/editor.rs
@@ -215,6 +215,10 @@ impl Editor {
                 data.session_mut().reverse_contours();
                 return (true, Some(EditType::Normal));
             }
+            c if c.is(consts::cmd::ROTATE_START_POINT) => {
+                data.session_mut().rotate_start_point();
+                return (true, Some(EditType::Normal));
+            }
             // all unhandled commands:
             _ => return (false, None),
         }


### PR DESCRIPTION
This is still a work in progress, I'm trying to add a command to the Paths menu that will let me rotate the start point of an outline. This is important for making variable fonts and interpolating between instances.