### PR TITLE
Add a set start point command

### DIFF
--- a/runebender-lib/src/consts.rs
+++ b/runebender-lib/src/consts.rs
@@ -55,6 +55,9 @@ pub mod cmd {
     // sent by 'reverse contours' menu item in Paths menu
     pub const REVERSE_CONTOURS: Selector = Selector::new("runebender.reverse-contours");
 
+    /// sent by 'set start point' menu item in Paths menu
+    pub const SET_START_POINT: Selector = Selector::new("runebender.set-start-point");
+
     /// Sent when a new tool has been selected.
     ///
     /// The payload must be a `ToolId`.

--- a/runebender-lib/src/edit_session.rs
+++ b/runebender-lib/src/edit_session.rs
@@ -511,6 +511,18 @@ impl EditSession {
         }
     }
 
+    pub(crate) fn set_start_point(&mut self, point: EntityId) {
+        if self.selection.len() == 1 {
+            log::info!("single point selected, setting start point");
+            for path in self.paths_mut() {
+                path.make_start(point);
+            }
+        } else {
+            log::info!("Multiple points selected, do nothing");
+            return;
+        }
+    }
+
     pub(crate) fn add_guide(&mut self, point: Point) {
         // if one or two points are selected, use them. else use argument point.
         let guide = match self.selection.len() {

--- a/runebender-lib/src/menus.rs
+++ b/runebender-lib/src/menus.rs
@@ -200,6 +200,14 @@ fn paths_menu<T: Data>() -> Menu<T> {
             .on_activate(|ctx, _, _| ctx.submit_command(consts::cmd::ALIGN_SELECTION))
             .hotkey(SysMods::CmdShift, "A"),
         )
+        .entry(
+            MenuItem::new(
+                LocalizedString::new("menu-item-set-start-point")
+                    .with_placeholder("Set Start Point"),
+            )
+            .on_activate(|ctx, _, _| ctx.submit_command(consts::cmd::SET_START_POINT))
+            .hotkey(SysMods::CmdShift, "P"),
+        )
 }
 
 fn window_menu(_app_state: &AppState) -> Menu<AppState> {

--- a/runebender-lib/src/path.rs
+++ b/runebender-lib/src/path.rs
@@ -185,6 +185,12 @@ impl Path {
         self.path_points().start_point()
     }
 
+    pub fn make_start(&mut self, point: EntityId) {
+        log::info!("make_start called from path.rs!");
+        self.path_points_mut().make_start(point);
+        self.after_change();
+    }
+
     /// Delete a collection of points from this path.
     ///
     /// If only a single point was deleted from this path, we will return

--- a/runebender-lib/src/point_list.rs
+++ b/runebender-lib/src/point_list.rs
@@ -398,6 +398,10 @@ impl PathPoints {
         self.points.as_ref().get(self.first_idx()).unwrap()
     }
 
+    pub fn make_start(&mut self, _point: EntityId) {
+        log::info!("make_start");
+    }
+
     /// Returns the 'last' on-curve point.
     ///
     /// In a closed path, this is the on-curve point preceding the start point.

--- a/runebender-lib/src/widgets/editor.rs
+++ b/runebender-lib/src/widgets/editor.rs
@@ -10,6 +10,7 @@ use crate::data::EditorState;
 use crate::draw;
 use crate::edit_session::EditSession;
 use crate::mouse::{Mouse, TaggedEvent};
+use crate::point::EntityId;
 use crate::theme;
 use crate::tools::{EditType, Preview, Select, Tool};
 use crate::undo::UndoState;
@@ -213,6 +214,14 @@ impl Editor {
             }
             c if c.is(consts::cmd::REVERSE_CONTOURS) => {
                 data.session_mut().reverse_contours();
+                return (true, Some(EditType::Normal));
+            }
+            c if c.is(consts::cmd::SET_START_POINT) => {
+                // This is just here to get an EntityId to get the editor to compile.
+                // I'm not sure what the best way to do this with a real EntityId is
+                // - Eli H
+                let id = EntityId::next();
+                data.session_mut().set_start_point(id);
                 return (true, Some(EditType::Normal));
             }
             // all unhandled commands:


### PR DESCRIPTION
This is an updated version of a previous PR I closed here: https://github.com/linebender/runebender/pull/260

This attempt is based on some feedback from the Zulip given by @cmyr:
>The identity of the 'start point' is determined by a convention: In an open path, it is the first point in the list, and in a closed path (which is the only case where changing the start point really makes sense) it is the last point in a list.
So to implement this:
ensure that the path is closed
ensure that there is one selected point, and it is an on-curve
rotate the points to put this point at the end of the list
I would start by adding a method in `point_list.rs`, `PathPoints::make_start(&mut self, point: EntityId)`. Then you'll want to call this from `edit_session` (likely via `Path`), passing in the id of the current selection.

Currently the command is in the `Paths` menu and works with the `Shift+Ctrl+P` command. If multiple points are selected it logs that info and does nothing, if one point is selected it calls `make_start` from `Path`.

I feel like I can figure most of what is needed with a bit more work, but I'm a bit lost on the best way to do this. Specifically how to get the right `EntityId` in `editor.rs` and how to rotate the points.

Any feedback is welcome, I think I can figure most of this out on my own, it just takes me a long time.

Thanks!

![2021-08-04-134622_1920x1080_scrot](https://user-images.githubusercontent.com/5162664/128229415-6a7e4c15-3e5b-44cc-9c4d-11ac68492bdc.png)
