### PR TITLE
Update coordinate pane and glyph edit window UI

### DIFF
--- a/runebender-lib/src/widgets/controller.rs
+++ b/runebender-lib/src/widgets/controller.rs
@@ -102,8 +102,8 @@ impl<W: Widget<EditorState>> Widget<EditorState> for EditorController<W> {
         let our_size = self.inner.layout(ctx, bc, data, env);
         let coords_size = self.coord_panel.layout(ctx, &child_bc, data, env);
         let coords_origin = (
-            (our_size.width) - coords_size.width - 24.0,
-            our_size.height - coords_size.height - 24.0,
+            (our_size.width) - coords_size.width - FLOATING_PANEL_PADDING,
+            our_size.height - coords_size.height - FLOATING_PANEL_PADDING,
         );
         let coord_frame = Rect::from_origin_size(coords_origin, coords_size);
         self.coord_panel

--- a/runebender-lib/src/widgets/controller.rs
+++ b/runebender-lib/src/widgets/controller.rs
@@ -9,7 +9,7 @@ use crate::edit_session::EditSession;
 use crate::widgets::{CoordPane, FloatingPanel, GlyphPane, Toolbar};
 
 /// the distance from the edge of a floating panel to the edge of the window.
-const FLOATING_PANEL_PADDING: f64 = 20.0;
+const FLOATING_PANEL_PADDING: f64 = 24.0;
 
 /// More like this is 'Editor' and 'Editor' is 'Canvas'?
 //TODO: we could combine this with controller above if we wanted?
@@ -102,8 +102,8 @@ impl<W: Widget<EditorState>> Widget<EditorState> for EditorController<W> {
         let our_size = self.inner.layout(ctx, bc, data, env);
         let coords_size = self.coord_panel.layout(ctx, &child_bc, data, env);
         let coords_origin = (
-            (our_size.width / 2.0) - coords_size.width / 2.0,
-            our_size.height - coords_size.height - 20.0,
+            (our_size.width) - coords_size.width - 24.0,
+            our_size.height - coords_size.height - 24.0,
         );
         let coord_frame = Rect::from_origin_size(coords_origin, coords_size);
         self.coord_panel

--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -125,10 +125,8 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
         SizedBox::empty(),
     );
 
-    let coord_label_font: FontDescriptor =
-        FontDescriptor::new(FontFamily::MONOSPACE);
-    let coord_font: FontDescriptor =
-        FontDescriptor::new(FontFamily::MONOSPACE);
+    let coord_label_font: FontDescriptor = FontDescriptor::new(FontFamily::MONOSPACE);
+    let coord_font: FontDescriptor = FontDescriptor::new(FontFamily::MONOSPACE);
 
     let coord_editor = Flex::column()
         .with_child(

--- a/runebender-lib/src/widgets/coord_pane.rs
+++ b/runebender-lib/src/widgets/coord_pane.rs
@@ -3,7 +3,7 @@
 
 use druid::kurbo::Circle;
 use druid::widget::{prelude::*, Controller, CrossAxisAlignment, Either, Flex, Label, SizedBox};
-use druid::{Color, FontDescriptor, FontFamily, FontStyle, Point, WidgetExt};
+use druid::{Color, FontDescriptor, FontFamily, Point, WidgetExt};
 
 use crate::design_space::{DPoint, DVec2};
 use crate::edit_session::CoordinateSelection;
@@ -90,18 +90,20 @@ impl Widget<Quadrant> for CoordRepresentationPicker {
 
     fn paint(&mut self, ctx: &mut PaintCtx, data: &Quadrant, env: &Env) {
         let frame_size = ctx.size();
-        let padding = 5.0;
-        let circle_radius = 2.5;
+        let padding = 8.0;
+        let circle_radius = 6.0;
         let rect = frame_size.to_rect().inset(-padding);
         ctx.stroke(rect, &Color::BLACK, 1.0);
         for quadrant in Quadrant::all() {
             let pt = quadrant.point_in_rect(rect);
             let color = if data == quadrant {
-                env.get(druid::theme::SELECTED_TEXT_BACKGROUND_COLOR)
+                env.get(theme::FOCUS_BACKGROUND_COLOR)
             } else {
-                Color::BLACK
+                env.get(theme::OFF_CURVE_POINT_OUTER_COLOR)
             };
+            let stroke_color = env.get(theme::PATH_FILL_COLOR);
             ctx.fill(Circle::new(pt, circle_radius), &color);
+            ctx.stroke(Circle::new(pt, circle_radius), &stroke_color, 1.0);
         }
     }
 }
@@ -118,13 +120,15 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
         |d, _| d.count > 1,
         CoordRepresentationPicker
             .lens(CoordinateSelection::quadrant)
-            .fix_width(40.0)
+            .fix_width(64.0)
             .padding((0., 0., 8.0, 0.)),
         SizedBox::empty(),
     );
 
     let coord_label_font: FontDescriptor =
-        FontDescriptor::new(FontFamily::SERIF).with_style(FontStyle::Italic);
+        FontDescriptor::new(FontFamily::MONOSPACE);
+    let coord_font: FontDescriptor =
+        FontDescriptor::new(FontFamily::MONOSPACE);
 
     let coord_editor = Flex::column()
         .with_child(
@@ -133,14 +137,16 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                 .with_child(
                     Label::new("x")
                         .with_font(coord_label_font.clone())
+                        .with_text_size(16.0)
                         .with_text_color(theme::SECONDARY_TEXT_COLOR)
                         .padding((0.0, 0.0, 0.0, 8.0)),
                 )
                 .with_child(
                     EditableLabel::parse()
-                        .with_font(theme::UI_DETAIL_FONT)
+                        .with_font(coord_font.clone())
+                        .with_text_size(16.0)
                         .lens(point_x_lens)
-                        .fix_width(40.0)
+                        .fix_width(64.0)
                         .padding((0.0, 0.0, 0.0, 8.0)),
                 ),
         )
@@ -150,13 +156,15 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                 .with_child(
                     Label::new("y")
                         .with_font(coord_label_font.clone())
+                        .with_text_size(16.0)
                         .with_text_color(theme::SECONDARY_TEXT_COLOR),
                 )
                 .with_child(
                     EditableLabel::parse()
-                        .with_font(theme::UI_DETAIL_FONT)
+                        .with_font(coord_font.clone())
+                        .with_text_size(16.0)
                         .lens(point_y_lens)
-                        .fix_width(40.0),
+                        .fix_width(64.0),
                 ),
         )
         .lens(CoordinateSelection::quadrant_coord);
@@ -169,15 +177,17 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     .with_child(
                         Label::new("w")
                             .with_font(coord_label_font.clone())
+                            .with_text_size(16.0)
                             .with_text_color(theme::SECONDARY_TEXT_COLOR)
-                            .padding((-0.0, 0.0, 0.0, 8.0)),
+                            .padding((8.0, 0.0, 0.0, 8.0)),
                     )
                     .with_spacer(0.0)
                     .with_child(
                         EditableLabel::parse()
-                            .with_font(theme::UI_DETAIL_FONT)
+                            .with_font(coord_font.clone())
+                            .with_text_size(16.0)
                             .lens(size_width_lens)
-                            .fix_width(40.0)
+                            .fix_width(64.0)
                             .padding((0.0, 0.0, 0.0, 8.0)),
                     ),
             )
@@ -186,14 +196,17 @@ fn build_widget() -> impl Widget<CoordinateSelection> {
                     .with_child(
                         Label::new("h")
                             .with_font(coord_label_font)
-                            .with_text_color(theme::SECONDARY_TEXT_COLOR),
+                            .with_text_size(16.0)
+                            .with_text_color(theme::SECONDARY_TEXT_COLOR)
+                            .padding((8.0, 0.0, 0.0, 0.0)),
                     )
                     .with_spacer(0.0)
                     .with_child(
                         EditableLabel::parse()
-                            .with_font(theme::UI_DETAIL_FONT)
+                            .with_font(coord_font.clone())
+                            .with_text_size(16.0)
                             .lens(size_height_lens)
-                            .fix_width(40.0),
+                            .fix_width(64.0),
                     ),
             )
             .lens(CoordinateSelection::quadrant_bbox),

--- a/runebender-lib/src/widgets/glyph_pane.rs
+++ b/runebender-lib/src/widgets/glyph_pane.rs
@@ -2,7 +2,7 @@
 //! glyph metrics
 
 use druid::widget::{prelude::*, Controller, Flex};
-use druid::{LensExt, WidgetExt};
+use druid::{FontDescriptor, FontFamily, LensExt, WidgetExt};
 
 use crate::data::{EditorState, GlyphDetail, Sidebearings};
 use crate::widgets::{EditableLabel, GlyphPainter};
@@ -57,12 +57,15 @@ impl<W: Widget<Sidebearings>> Controller<Sidebearings, W> for GlyphPane {
 }
 
 fn build_widget() -> impl Widget<EditorState> {
+    let glyph_font: FontDescriptor =
+        FontDescriptor::new(FontFamily::MONOSPACE);
     Flex::column()
         .with_child(
             Flex::row()
                 .with_child(
                     EditableLabel::parse()
-                        .with_font(theme::UI_DETAIL_FONT)
+                        .with_font(glyph_font.clone())
+                        .with_text_size(16.0)
                         .with_text_alignment(druid::TextAlignment::End)
                         .lens(Sidebearings::left)
                         .controller(GlyphPane)
@@ -73,13 +76,14 @@ fn build_widget() -> impl Widget<EditorState> {
                     GlyphPainter::new()
                         .color(theme::SECONDARY_TEXT_COLOR)
                         .draw_layout_frame(true)
-                        .fix_height(200.0)
+                        .fix_height(128.0)
                         .padding((8.0, 8.0))
                         .lens(EditorState::detail_glyph),
                 )
                 .with_child(
                     EditableLabel::parse()
-                        .with_font(theme::UI_DETAIL_FONT)
+                        .with_font(glyph_font.clone())
+                        .with_text_size(16.0)
                         .with_text_alignment(druid::TextAlignment::Start)
                         .lens(Sidebearings::right)
                         .controller(GlyphPane)
@@ -89,10 +93,11 @@ fn build_widget() -> impl Widget<EditorState> {
         )
         .with_child(
             EditableLabel::parse()
-                .with_font(theme::UI_DETAIL_FONT)
+                .with_font(glyph_font.clone())
+                .with_text_size(16.0)
                 .with_text_alignment(druid::TextAlignment::Center)
                 .lens(EditorState::detail_glyph.then(GlyphDetail::advance))
-                .fix_width(40.0),
+                .fix_width(64.0),
         )
         .padding(8.0)
 }

--- a/runebender-lib/src/widgets/glyph_pane.rs
+++ b/runebender-lib/src/widgets/glyph_pane.rs
@@ -57,8 +57,7 @@ impl<W: Widget<Sidebearings>> Controller<Sidebearings, W> for GlyphPane {
 }
 
 fn build_widget() -> impl Widget<EditorState> {
-    let glyph_font: FontDescriptor =
-        FontDescriptor::new(FontFamily::MONOSPACE);
+    let glyph_font: FontDescriptor = FontDescriptor::new(FontFamily::MONOSPACE);
     Flex::column()
         .with_child(
             Flex::row()

--- a/runebender-lib/src/widgets/toolbar.rs
+++ b/runebender-lib/src/widgets/toolbar.rs
@@ -8,9 +8,9 @@ use druid::{Color, Data, HotKey, KeyEvent, Rect, SysMods, WidgetPod};
 use crate::consts;
 use crate::tools::ToolId;
 
-const TOOLBAR_ITEM_SIZE: Size = Size::new(40.0, 40.0);
+const TOOLBAR_ITEM_SIZE: Size = Size::new(48.0, 48.0);
 const TOOLBAR_ITEM_PADDING: f64 = 2.0;
-const TOOLBAR_ICON_PADDING: f64 = 5.0;
+const TOOLBAR_ICON_PADDING: f64 = 6.0;
 const TOOLBAR_BORDER_STROKE_WIDTH: f64 = 2.0;
 const TOOLBAR_ITEM_STROKE_WIDTH: f64 = 1.5;
 // TODO: move these to theme


### PR DESCRIPTION
This PR makes an update mainly attempting to improve the UI/UX for the coordinate pane, based on my experience using the editor.

- Adds a redesign of the visual style of the coordinate pane for better legibility and easier hit targets for mouse clicks
- Adjusts the font and text size of the glyph pane to match the new coordinate pane
- Adjusts the size of the toolbar for better visual harmony with the coordinate pane and icon legibility
- Adjust the controller margin for the 8 unit spacing grid used in other UI elements
- Move the coordinate pane to the right side of the window, this needs some logic that puts the coordinate pane in the center when the window is wider than 700 units still, but I thought that could be in a separate PR.

If this is too much for one PR, just let me know and I can break this up into smaller PRs. Tested on GTK+Linux and MacOS Big Sur, screenshots below:

![2021-08-10-023429_1920x1080_scrot](https://user-images.githubusercontent.com/5162664/128822008-045cb6b4-4aa4-416a-be50-4c253bf1761c.png)
<img width="933" alt=" rb-2021-08-09-at-11 44 46-PM" src="https://user-images.githubusercontent.com/5162664/128822020-d5c29ea8-524b-4e06-b28f-7146ee0b6524.png">
